### PR TITLE
allow for custom pdf url

### DIFF
--- a/fetch-and-store.js
+++ b/fetch-and-store.js
@@ -467,7 +467,11 @@ const getPublications = async () => {
 
         const {data: publicationHtml} = await axios.get(landingUrl);
         const $$ = cheerio.load(publicationHtml);
-        const pdfUrl = $$("a.health-file__link").attr('href');
+        var pdfUrl = $$("a.health-file__link").attr('href');
+
+        if(landingUrl.includes('.pdf')){
+        pdfUrl = landingUrl;
+        }
 
         const { data: pdfBuffer } = await axios.get(pdfUrl, {
             params: {


### PR DESCRIPTION
if the custom landing url contains `.pdf` then it will just use the landing url and the pdf url so you can use custom pdf urls