### PR TITLE
fix(): incorrect lower bound in air_residence

### DIFF
--- a/docs/data/2021-07-27.json
+++ b/docs/data/2021-07-27.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.04,
                         "secondDosePct": 17.21,
                         "firstDoseCount": 2563251,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.89,
                         "secondDosePct": 17.64,
                         "firstDoseCount": 2211422,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 35.86,
                         "secondDosePct": 16.8,
                         "firstDoseCount": 1474997,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.53,
                         "secondDosePct": 21.4,
                         "firstDoseCount": 160096,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.84,
                         "secondDosePct": 17.63,
                         "firstDoseCount": 573887,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.52,
                         "secondDosePct": 21.91,
                         "firstDoseCount": 75320,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 35.88,
                         "secondDosePct": 14.4,
                         "firstDoseCount": 758897,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.06,
                         "secondDosePct": 22.79,
                         "firstDoseCount": 207162,

--- a/docs/data/2021-07-28.json
+++ b/docs/data/2021-07-28.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.49,
                         "secondDosePct": 17.61,
                         "firstDoseCount": 2592831,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.02,
                         "secondDosePct": 18,
                         "firstDoseCount": 2217957,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 35.94,
                         "secondDosePct": 17.11,
                         "firstDoseCount": 1478088,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.1,
                         "secondDosePct": 21.32,
                         "firstDoseCount": 158586,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.02,
                         "secondDosePct": 17.96,
                         "firstDoseCount": 576441,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.57,
                         "secondDosePct": 22.99,
                         "firstDoseCount": 77317,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 36.06,
                         "secondDosePct": 14.86,
                         "firstDoseCount": 762665,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47,
                         "secondDosePct": 23.02,
                         "firstDoseCount": 206900,

--- a/docs/data/2021-07-29.json
+++ b/docs/data/2021-07-29.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.16,
                         "secondDosePct": 18.14,
                         "firstDoseCount": 2636949,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.4,
                         "secondDosePct": 18.48,
                         "firstDoseCount": 2238886,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 36.28,
                         "secondDosePct": 17.62,
                         "firstDoseCount": 1492204,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.31,
                         "secondDosePct": 21.66,
                         "firstDoseCount": 159327,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.45,
                         "secondDosePct": 18.49,
                         "firstDoseCount": 582657,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.09,
                         "secondDosePct": 23.58,
                         "firstDoseCount": 78307,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 36.49,
                         "secondDosePct": 15.38,
                         "firstDoseCount": 771680,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.6,
                         "secondDosePct": 23.54,
                         "firstDoseCount": 209540,

--- a/docs/data/2021-07-30.json
+++ b/docs/data/2021-07-30.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.95,
                         "secondDosePct": 18.72,
                         "firstDoseCount": 2688735,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.78,
                         "secondDosePct": 18.94,
                         "firstDoseCount": 2259057,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 36.63,
                         "secondDosePct": 18.07,
                         "firstDoseCount": 1506591,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.16,
                         "secondDosePct": 22.36,
                         "firstDoseCount": 162249,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.86,
                         "secondDosePct": 18.95,
                         "firstDoseCount": 588564,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.64,
                         "secondDosePct": 24.22,
                         "firstDoseCount": 79356,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 36.88,
                         "secondDosePct": 15.84,
                         "firstDoseCount": 780076,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.96,
                         "secondDosePct": 24.08,
                         "firstDoseCount": 211096,

--- a/docs/data/2021-07-31.json
+++ b/docs/data/2021-07-31.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.37,
                         "secondDosePct": 19.07,
                         "firstDoseCount": 2715978,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.04,
                         "secondDosePct": 19.2,
                         "firstDoseCount": 2273154,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 36.83,
                         "secondDosePct": 18.32,
                         "firstDoseCount": 1514557,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.59,
                         "secondDosePct": 22.88,
                         "firstDoseCount": 163728,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.09,
                         "secondDosePct": 19.16,
                         "firstDoseCount": 591855,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.87,
                         "secondDosePct": 24.43,
                         "firstDoseCount": 79787,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 37.17,
                         "secondDosePct": 16.12,
                         "firstDoseCount": 786126,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.35,
                         "secondDosePct": 24.41,
                         "firstDoseCount": 212831,

--- a/docs/data/2021-08-01.json
+++ b/docs/data/2021-08-01.json
@@ -769,7 +769,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.57,
                         "secondDosePct": 19.28,
                         "firstDoseCount": 2729174,
@@ -951,7 +951,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.24,
                         "secondDosePct": 19.37,
                         "firstDoseCount": 2283955,
@@ -1133,7 +1133,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 36.97,
                         "secondDosePct": 18.47,
                         "firstDoseCount": 1520478,
@@ -1315,7 +1315,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.68,
                         "secondDosePct": 23.06,
                         "firstDoseCount": 164048,
@@ -1497,7 +1497,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.23,
                         "secondDosePct": 19.31,
                         "firstDoseCount": 593907,
@@ -1679,7 +1679,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.04,
                         "secondDosePct": 24.48,
                         "firstDoseCount": 80109,
@@ -1861,7 +1861,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 37.4,
                         "secondDosePct": 16.33,
                         "firstDoseCount": 790907,
@@ -2043,7 +2043,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.53,
                         "secondDosePct": 24.66,
                         "firstDoseCount": 213633,

--- a/docs/data/2021-08-02.json
+++ b/docs/data/2021-08-02.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.23,
                         "secondDosePct": 19.81,
                         "firstDoseCount": 2772428,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.58,
                         "secondDosePct": 19.85,
                         "firstDoseCount": 2302523,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 37.26,
                         "secondDosePct": 18.82,
                         "firstDoseCount": 1532546,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.88,
                         "secondDosePct": 23.92,
                         "firstDoseCount": 168170,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.64,
                         "secondDosePct": 19.75,
                         "firstDoseCount": 599826,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.16,
                         "secondDosePct": 24.62,
                         "firstDoseCount": 80352,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 37.67,
                         "secondDosePct": 16.83,
                         "firstDoseCount": 796736,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.81,
                         "secondDosePct": 25.08,
                         "firstDoseCount": 214854,

--- a/docs/data/2021-08-03.json
+++ b/docs/data/2021-08-03.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.04,
                         "secondDosePct": 20.44,
                         "firstDoseCount": 2825917,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.92,
                         "secondDosePct": 20.29,
                         "firstDoseCount": 2320875,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 37.68,
                         "secondDosePct": 19.34,
                         "firstDoseCount": 1549491,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 49.4,
                         "secondDosePct": 24.43,
                         "firstDoseCount": 169974,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.07,
                         "secondDosePct": 20.23,
                         "firstDoseCount": 605951,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.57,
                         "secondDosePct": 25.03,
                         "firstDoseCount": 81129,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 38,
                         "secondDosePct": 17.39,
                         "firstDoseCount": 803715,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 49.2,
                         "secondDosePct": 25.7,
                         "firstDoseCount": 216586,

--- a/docs/data/2021-08-04.json
+++ b/docs/data/2021-08-04.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.78,
                         "secondDosePct": 21.04,
                         "firstDoseCount": 2874425,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.26,
                         "secondDosePct": 20.8,
                         "firstDoseCount": 2339301,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 38.19,
                         "secondDosePct": 19.95,
                         "firstDoseCount": 1570498,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 49.65,
                         "secondDosePct": 24.77,
                         "firstDoseCount": 170831,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.53,
                         "secondDosePct": 20.8,
                         "firstDoseCount": 612645,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.04,
                         "secondDosePct": 25.7,
                         "firstDoseCount": 82018,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 38.39,
                         "secondDosePct": 17.9,
                         "firstDoseCount": 811909,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 49.58,
                         "secondDosePct": 26.25,
                         "firstDoseCount": 218238,

--- a/docs/data/2021-08-05.json
+++ b/docs/data/2021-08-05.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.66,
                         "secondDosePct": 21.68,
                         "firstDoseCount": 2931990,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.62,
                         "secondDosePct": 21.31,
                         "firstDoseCount": 2358825,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 38.74,
                         "secondDosePct": 20.55,
                         "firstDoseCount": 1593427,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 49.86,
                         "secondDosePct": 25.07,
                         "firstDoseCount": 171540,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.96,
                         "secondDosePct": 21.32,
                         "firstDoseCount": 618807,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.63,
                         "secondDosePct": 26.28,
                         "firstDoseCount": 83141,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 38.84,
                         "secondDosePct": 18.46,
                         "firstDoseCount": 821478,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 50.08,
                         "secondDosePct": 26.76,
                         "firstDoseCount": 220446,

--- a/docs/data/2021-08-06.json
+++ b/docs/data/2021-08-06.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.46,
                         "secondDosePct": 22.29,
                         "firstDoseCount": 2984776,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44,
                         "secondDosePct": 21.87,
                         "firstDoseCount": 2379619,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.34,
                         "secondDosePct": 21.12,
                         "firstDoseCount": 1618162,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 50.44,
                         "secondDosePct": 25.64,
                         "firstDoseCount": 173549,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.37,
                         "secondDosePct": 21.83,
                         "firstDoseCount": 624716,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.16,
                         "secondDosePct": 26.83,
                         "firstDoseCount": 84153,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.22,
                         "secondDosePct": 18.97,
                         "firstDoseCount": 829564,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 50.48,
                         "secondDosePct": 27.2,
                         "firstDoseCount": 222184,

--- a/docs/data/2021-08-07.json
+++ b/docs/data/2021-08-07.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.94,
                         "secondDosePct": 22.87,
                         "firstDoseCount": 3016441,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.25,
                         "secondDosePct": 22.22,
                         "firstDoseCount": 2392900,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.66,
                         "secondDosePct": 21.41,
                         "firstDoseCount": 1631002,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 50.85,
                         "secondDosePct": 26.08,
                         "firstDoseCount": 174961,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.63,
                         "secondDosePct": 22.13,
                         "firstDoseCount": 628406,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.38,
                         "secondDosePct": 27.18,
                         "firstDoseCount": 84574,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.49,
                         "secondDosePct": 19.3,
                         "firstDoseCount": 835216,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 50.88,
                         "secondDosePct": 27.67,
                         "firstDoseCount": 223977,

--- a/docs/data/2021-08-08.json
+++ b/docs/data/2021-08-08.json
@@ -769,7 +769,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.2,
                         "secondDosePct": 23.01,
                         "firstDoseCount": 3033491,
@@ -951,7 +951,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.47,
                         "secondDosePct": 22.47,
                         "firstDoseCount": 2404557,
@@ -1133,7 +1133,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.88,
                         "secondDosePct": 21.57,
                         "firstDoseCount": 1640384,
@@ -1315,7 +1315,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 50.99,
                         "secondDosePct": 26.38,
                         "firstDoseCount": 175425,
@@ -1497,7 +1497,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.82,
                         "secondDosePct": 22.32,
                         "firstDoseCount": 631126,
@@ -1679,7 +1679,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.48,
                         "secondDosePct": 27.23,
                         "firstDoseCount": 84762,
@@ -1861,7 +1861,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.69,
                         "secondDosePct": 19.56,
                         "firstDoseCount": 839402,
@@ -2043,7 +2043,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 51.08,
                         "secondDosePct": 27.97,
                         "firstDoseCount": 224856,

--- a/docs/data/2021-08-09.json
+++ b/docs/data/2021-08-09.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.99,
                         "secondDosePct": 23.59,
                         "firstDoseCount": 3085235,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.89,
                         "secondDosePct": 23.03,
                         "firstDoseCount": 2427550,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.24,
                         "secondDosePct": 21.95,
                         "firstDoseCount": 1655238,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 51.88,
                         "secondDosePct": 27.14,
                         "firstDoseCount": 178484,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.21,
                         "secondDosePct": 22.79,
                         "firstDoseCount": 636881,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.05,
                         "secondDosePct": 27.69,
                         "firstDoseCount": 85850,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 39.98,
                         "secondDosePct": 20.13,
                         "firstDoseCount": 845629,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 51.43,
                         "secondDosePct": 28.64,
                         "firstDoseCount": 226367,

--- a/docs/data/2021-08-10.json
+++ b/docs/data/2021-08-10.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.06,
                         "secondDosePct": 24.36,
                         "firstDoseCount": 3155892,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.35,
                         "secondDosePct": 23.59,
                         "firstDoseCount": 2452203,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.74,
                         "secondDosePct": 22.51,
                         "firstDoseCount": 1675486,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 52.1,
                         "secondDosePct": 27.47,
                         "firstDoseCount": 179252,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.67,
                         "secondDosePct": 23.39,
                         "firstDoseCount": 643415,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.56,
                         "secondDosePct": 28.21,
                         "firstDoseCount": 86838,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.37,
                         "secondDosePct": 20.69,
                         "firstDoseCount": 853792,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 51.74,
                         "secondDosePct": 29.37,
                         "firstDoseCount": 227765,

--- a/docs/data/2021-08-11.json
+++ b/docs/data/2021-08-11.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 49.01,
                         "secondDosePct": 25.06,
                         "firstDoseCount": 3218397,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.85,
                         "secondDosePct": 24.2,
                         "firstDoseCount": 2479545,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.26,
                         "secondDosePct": 23.07,
                         "firstDoseCount": 1697002,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 52.55,
                         "secondDosePct": 28.2,
                         "firstDoseCount": 180795,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.1,
                         "secondDosePct": 24.01,
                         "firstDoseCount": 649580,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.17,
                         "secondDosePct": 28.83,
                         "firstDoseCount": 88006,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 40.79,
                         "secondDosePct": 21.3,
                         "firstDoseCount": 862697,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 52.09,
                         "secondDosePct": 30.06,
                         "firstDoseCount": 229308,

--- a/docs/data/2021-08-12.json
+++ b/docs/data/2021-08-12.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 49.95,
                         "secondDosePct": 25.79,
                         "firstDoseCount": 3280156,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.37,
                         "secondDosePct": 24.79,
                         "firstDoseCount": 2507925,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.86,
                         "secondDosePct": 23.66,
                         "firstDoseCount": 1721652,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 52.81,
                         "secondDosePct": 28.61,
                         "firstDoseCount": 181701,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.52,
                         "secondDosePct": 24.69,
                         "firstDoseCount": 655701,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.82,
                         "secondDosePct": 29.46,
                         "firstDoseCount": 89241,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.21,
                         "secondDosePct": 21.92,
                         "firstDoseCount": 871653,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 52.54,
                         "secondDosePct": 30.98,
                         "firstDoseCount": 231265,

--- a/docs/data/2021-08-13.json
+++ b/docs/data/2021-08-13.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 50.95,
                         "secondDosePct": 26.54,
                         "firstDoseCount": 3345335,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.94,
                         "secondDosePct": 25.43,
                         "firstDoseCount": 2538663,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.41,
                         "secondDosePct": 24.23,
                         "firstDoseCount": 1744341,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 53.86,
                         "secondDosePct": 29.94,
                         "firstDoseCount": 185330,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.95,
                         "secondDosePct": 25.28,
                         "firstDoseCount": 661822,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.4,
                         "secondDosePct": 29.99,
                         "firstDoseCount": 90354,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.62,
                         "secondDosePct": 22.51,
                         "firstDoseCount": 880259,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 52.91,
                         "secondDosePct": 31.65,
                         "firstDoseCount": 232915,

--- a/docs/data/2021-08-14.json
+++ b/docs/data/2021-08-14.json
@@ -698,7 +698,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 51.55,
                         "secondDosePct": 26.92,
                         "firstDoseCount": 3385107,
@@ -880,7 +880,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.3,
                         "secondDosePct": 25.84,
                         "firstDoseCount": 2558270,
@@ -1062,7 +1062,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.77,
                         "secondDosePct": 24.56,
                         "firstDoseCount": 1759181,
@@ -1244,7 +1244,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 54.06,
                         "secondDosePct": 30.31,
                         "firstDoseCount": 186020,
@@ -1426,7 +1426,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.2,
                         "secondDosePct": 25.59,
                         "firstDoseCount": 665487,
@@ -1608,7 +1608,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.63,
                         "secondDosePct": 30.28,
                         "firstDoseCount": 90793,
@@ -1790,7 +1790,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 41.94,
                         "secondDosePct": 22.86,
                         "firstDoseCount": 886964,
@@ -1972,7 +1972,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 53.16,
                         "secondDosePct": 32.27,
                         "firstDoseCount": 233998,

--- a/docs/data/2021-08-15.json
+++ b/docs/data/2021-08-15.json
@@ -697,7 +697,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 52.05,
                         "secondDosePct": 27.13,
                         "firstDoseCount": 3417891,
@@ -879,7 +879,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.39,
                         "secondDosePct": 25.94,
                         "firstDoseCount": 2563162,
@@ -1061,7 +1061,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.02,
                         "secondDosePct": 24.71,
                         "firstDoseCount": 1769610,
@@ -1243,7 +1243,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 54.17,
                         "secondDosePct": 30.47,
                         "firstDoseCount": 186398,
@@ -1425,7 +1425,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.37,
                         "secondDosePct": 25.76,
                         "firstDoseCount": 667989,
@@ -1607,7 +1607,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.75,
                         "secondDosePct": 30.38,
                         "firstDoseCount": 91020,
@@ -1789,7 +1789,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.16,
                         "secondDosePct": 23.16,
                         "firstDoseCount": 891740,
@@ -1971,7 +1971,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 53.38,
                         "secondDosePct": 32.53,
                         "firstDoseCount": 234964,

--- a/docs/data/2021-08-16.json
+++ b/docs/data/2021-08-16.json
@@ -732,7 +732,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 53.01,
                         "secondDosePct": 27.81,
                         "firstDoseCount": 3480823,
@@ -914,7 +914,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.11,
                         "secondDosePct": 26.68,
                         "firstDoseCount": 2601959,
@@ -1096,7 +1096,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.49,
                         "secondDosePct": 25.18,
                         "firstDoseCount": 1789060,
@@ -1278,7 +1278,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 54.78,
                         "secondDosePct": 31.27,
                         "firstDoseCount": 188473,
@@ -1460,7 +1460,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 46.78,
                         "secondDosePct": 26.35,
                         "firstDoseCount": 673854,
@@ -1642,7 +1642,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.28,
                         "secondDosePct": 30.73,
                         "firstDoseCount": 92034,
@@ -1824,7 +1824,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 42.71,
                         "secondDosePct": 23.81,
                         "firstDoseCount": 903289,
@@ -2006,7 +2006,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 53.79,
                         "secondDosePct": 33.09,
                         "firstDoseCount": 236769,

--- a/docs/data/2021-08-17.json
+++ b/docs/data/2021-08-17.json
@@ -732,7 +732,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 54.02,
                         "secondDosePct": 28.5,
                         "firstDoseCount": 3547120,
@@ -914,7 +914,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.67,
                         "secondDosePct": 27.28,
                         "firstDoseCount": 2632389,
@@ -1096,7 +1096,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.05,
                         "secondDosePct": 25.71,
                         "firstDoseCount": 1811893,
@@ -1278,7 +1278,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 55.9,
                         "secondDosePct": 32.18,
                         "firstDoseCount": 192325,
@@ -1460,7 +1460,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.25,
                         "secondDosePct": 26.97,
                         "firstDoseCount": 680678,
@@ -1642,7 +1642,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.94,
                         "secondDosePct": 31.17,
                         "firstDoseCount": 93291,
@@ -1824,7 +1824,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.22,
                         "secondDosePct": 27.28,
                         "firstDoseCount": 914091,
@@ -2006,7 +2006,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 54.2,
                         "secondDosePct": 33.79,
                         "firstDoseCount": 238592,

--- a/docs/data/2021-08-18.json
+++ b/docs/data/2021-08-18.json
@@ -732,7 +732,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 55.23,
                         "secondDosePct": 29.32,
                         "firstDoseCount": 3625997,
@@ -914,7 +914,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 49.25,
                         "secondDosePct": 27.96,
                         "firstDoseCount": 2663345,
@@ -1096,7 +1096,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.66,
                         "secondDosePct": 26.3,
                         "firstDoseCount": 1836767,
@@ -1278,7 +1278,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 56.43,
                         "secondDosePct": 32.59,
                         "firstDoseCount": 194124,
@@ -1460,7 +1460,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 47.79,
                         "secondDosePct": 27.64,
                         "firstDoseCount": 688316,
@@ -1642,7 +1642,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 49.7,
                         "secondDosePct": 31.89,
                         "firstDoseCount": 94719,
@@ -1824,7 +1824,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 43.92,
                         "secondDosePct": 25.06,
                         "firstDoseCount": 928831,
@@ -2006,7 +2006,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 54.64,
                         "secondDosePct": 34.44,
                         "firstDoseCount": 240512,

--- a/docs/data/2021-08-19.json
+++ b/docs/data/2021-08-19.json
@@ -732,7 +732,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 56.35,
                         "secondDosePct": 30.05,
                         "firstDoseCount": 3699581,
@@ -914,7 +914,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 49.85,
                         "secondDosePct": 28.65,
                         "firstDoseCount": 2695760,
@@ -1096,7 +1096,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.24,
                         "secondDosePct": 26.84,
                         "firstDoseCount": 1860669,
@@ -1278,7 +1278,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 57.54,
                         "secondDosePct": 34.13,
                         "firstDoseCount": 197963,
@@ -1460,7 +1460,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.27,
                         "secondDosePct": 28.29,
                         "firstDoseCount": 695320,
@@ -1642,7 +1642,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 50.48,
                         "secondDosePct": 32.58,
                         "firstDoseCount": 96208,
@@ -1824,7 +1824,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 44.58,
                         "secondDosePct": 25.73,
                         "firstDoseCount": 942781,
@@ -2006,7 +2006,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 55.08,
                         "secondDosePct": 35.34,
                         "firstDoseCount": 242440,

--- a/docs/data/2021-08-20.json
+++ b/docs/data/2021-08-20.json
@@ -732,7 +732,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 57.56,
                         "secondDosePct": 30.81,
                         "firstDoseCount": 3779127,
@@ -914,7 +914,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 50.43,
                         "secondDosePct": 29.37,
                         "firstDoseCount": 2726850,
@@ -1096,7 +1096,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.88,
                         "secondDosePct": 27.4,
                         "firstDoseCount": 1887055,
@@ -1278,7 +1278,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 58.75,
                         "secondDosePct": 35.7,
                         "firstDoseCount": 202117,
@@ -1460,7 +1460,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 48.78,
                         "secondDosePct": 28.96,
                         "firstDoseCount": 702665,
@@ -1642,7 +1642,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 51.16,
                         "secondDosePct": 33.24,
                         "firstDoseCount": 97499,
@@ -1824,7 +1824,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 45.13,
                         "secondDosePct": 26.36,
                         "firstDoseCount": 954557,
@@ -2006,7 +2006,7 @@
                 ],
                 "ageBucketsActualPopulation": [
                     {
-                        "ageLower": 0,
+                        "ageLower": 16,
                         "firstDosePct": 55.51,
                         "secondDosePct": 35.98,
                         "firstDoseCount": 244333,

--- a/docs/data/air_residence.csv
+++ b/docs/data/air_residence.csv
@@ -16,7 +16,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-27,NSW,25,29,15.7,8.77,,,95439,53312,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,NSW,20,24,12.77,6.72,,,68988,36304,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,NSW,16,19,5.46,2.49,,,20498,9348,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
-2021-07-27,NSW,0,999,39.04,17.21,2563251,1129924,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
+2021-07-27,NSW,16,999,39.04,17.21,2563251,1129924,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,NSW,50,999,62.99,25.07,1768524,703890,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,NSW,70,999,77.82,39.51,749125,380350,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,VIC,95,999,73.36,49.59,,,10367,7008,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
@@ -36,7 +36,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-27,VIC,25,29,13.15,8.73,,,70378,46722,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,VIC,20,24,10.02,6.3,,,47249,29708,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,VIC,16,19,3.09,1.5,,,9392,4559,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
-2021-07-27,VIC,0,999,40.89,17.64,2211422,954068,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
+2021-07-27,VIC,16,999,40.89,17.64,2211422,954068,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,VIC,50,999,67.8,21.35,1499247,471987,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,VIC,70,999,78.59,36.89,584322,274267,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,QLD,95,999,70.55,48.47,,,6391,4391,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
@@ -56,7 +56,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-27,QLD,25,29,13.68,9.01,,,50680,33379,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,QLD,20,24,11.58,6.84,,,39236,23176,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,QLD,16,19,4.74,2.29,,,12068,5830,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
-2021-07-27,QLD,0,999,35.86,16.8,1474997,690968,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
+2021-07-27,QLD,16,999,35.86,16.8,1474997,690968,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,QLD,50,999,60.04,24.25,1056084,426505,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,QLD,70,999,77.6,39.7,448354,229354,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,ACT,95,999,96.08,66.09,,,612,421,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
@@ -76,7 +76,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-27,ACT,25,29,17.74,11.55,,,6030,3926,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,ACT,20,24,11.78,7.24,,,3843,2362,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,ACT,16,19,4.85,2.53,,,935,488,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
-2021-07-27,ACT,0,999,46.53,21.4,160096,73615,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
+2021-07-27,ACT,16,999,46.53,21.4,160096,73615,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,ACT,50,999,78.19,28.15,99922,35970,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,ACT,70,999,91.7,50.15,36629,20033,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,SA,95,999,75.4,51.65,,,3752,2570,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
@@ -96,7 +96,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-27,SA,25,29,14.55,9.94,,,17132,11704,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,SA,20,24,11.76,7.44,,,13456,8513,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,SA,16,19,5.52,2.76,,,4525,2262,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
-2021-07-27,SA,0,999,39.84,17.63,573887,253881,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
+2021-07-27,SA,16,999,39.84,17.63,573887,253881,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,SA,50,999,61.45,22.02,414438,148507,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,SA,70,999,76.43,35.19,183825,84629,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,NT,95,999,27.84,19.59,,,27,19,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
@@ -116,7 +116,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-27,NT,25,29,27.78,17.77,,,6120,3915,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,NT,20,24,24.25,13.5,,,3903,2173,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,NT,16,19,19.5,9.2,,,2360,1113,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
-2021-07-27,NT,0,999,39.52,21.91,75320,41763,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
+2021-07-27,NT,16,999,39.52,21.91,75320,41763,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,NT,50,999,53.83,23.93,33523,14902,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,NT,70,999,48.99,27.89,6047,3443,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,WA,95,999,71.57,49.04,,,3282,2249,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
@@ -136,7 +136,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-27,WA,25,29,9.97,6.9,,,18431,12756,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,WA,20,24,7.97,5.1,,,13287,8502,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,WA,16,19,2.06,0.92,,,2546,1137,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
-2021-07-27,WA,0,999,35.88,14.4,758897,304651,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
+2021-07-27,WA,16,999,35.88,14.4,758897,304651,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,WA,50,999,61.08,21.35,540783,189016,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,WA,70,999,76.13,36.7,213387,102875,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,TAS,95,999,73.73,50.65,,,856,588,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
@@ -156,7 +156,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-27,TAS,25,29,23.27,14.6,,,7939,4981,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,TAS,20,24,16.29,10.16,,,5154,3215,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,TAS,16,19,5.75,2.93,,,1421,724,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
-2021-07-27,TAS,0,999,47.06,22.79,207162,100316,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
+2021-07-27,TAS,16,999,47.06,22.79,207162,100316,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,TAS,50,999,69.13,29.79,152109,65556,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-27,TAS,70,999,82.93,46.65,63987,35996,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-28-july-2021.pdf
 2021-07-28,NSW,95,999,72.26,49.99,,,13191,9126,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
@@ -176,7 +176,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-28,NSW,25,29,15.99,8.85,,,97202,53798,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,NSW,20,24,13.13,6.81,,,70933,36790,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,NSW,16,19,5.74,2.55,,,21549,9573,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
-2021-07-28,NSW,0,999,39.49,17.61,2592831,1156321,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
+2021-07-28,NSW,16,999,39.49,17.61,2592831,1156321,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,NSW,50,999,63.26,25.72,1776096,722229,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,NSW,70,999,77.45,40,745525,384995,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,VIC,95,999,70.43,47.53,,,9952,6716,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
@@ -196,7 +196,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-28,VIC,25,29,13.16,8.65,,,70431,46294,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,VIC,20,24,10.15,6.31,,,47862,29755,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,VIC,16,19,3.2,1.55,,,9727,4711,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
-2021-07-28,VIC,0,999,41.02,18,2217957,973629,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
+2021-07-28,VIC,16,999,41.02,18,2217957,973629,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,VIC,50,999,67.83,22.09,1499929,488430,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,VIC,70,999,78.22,37.49,581617,278766,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,QLD,95,999,67.29,46.45,,,6096,4208,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
@@ -216,7 +216,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-28,QLD,25,29,13.63,8.95,,,50495,33157,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,QLD,20,24,11.61,6.9,,,39337,23379,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,QLD,16,19,4.8,2.32,,,12220,5906,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
-2021-07-28,QLD,0,999,35.94,17.11,1478088,703491,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
+2021-07-28,QLD,16,999,35.94,17.11,1478088,703491,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,QLD,50,999,60.05,24.81,1056113,436341,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,QLD,70,999,77.22,40.29,446152,232772,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,ACT,95,999,90.89,62.79,,,579,400,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
@@ -236,7 +236,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-28,ACT,25,29,17.23,11.08,,,5857,3766,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,ACT,20,24,11.42,7.02,,,3726,2290,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,ACT,16,19,4.74,2.46,,,913,474,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
-2021-07-28,ACT,0,999,46.1,21.32,158586,73361,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
+2021-07-28,ACT,16,999,46.1,21.32,158586,73361,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,ACT,50,999,77.86,28.53,99511,36457,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,ACT,70,999,91.27,50.65,36460,20233,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,SA,95,999,72.31,49.46,,,3598,2461,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
@@ -256,7 +256,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-28,SA,25,29,14.64,9.99,,,17238,11763,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,SA,20,24,11.85,7.48,,,13559,8559,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,SA,16,19,5.62,2.83,,,4607,2320,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
-2021-07-28,SA,0,999,40.02,17.96,576441,258706,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
+2021-07-28,SA,16,999,40.02,17.96,576441,258706,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,SA,50,999,61.61,22.56,415515,152168,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,SA,70,999,76.25,35.76,183388,86003,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,NT,95,999,48.45,32.99,,,47,32,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
@@ -276,7 +276,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-28,NT,25,29,28.74,18.36,,,6332,4045,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,NT,20,24,23.36,13.33,,,3760,2145,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,NT,16,19,18.74,9.45,,,2268,1144,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
-2021-07-28,NT,0,999,40.57,22.99,77317,43820,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
+2021-07-28,NT,16,999,40.57,22.99,77317,43820,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,NT,50,999,57.8,27.03,36000,16835,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,NT,70,999,70.08,41.52,8650,5125,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,WA,95,999,68.99,47.41,,,3164,2174,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
@@ -296,7 +296,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-28,WA,25,29,10.1,6.95,,,18671,12848,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,WA,20,24,8.1,5.17,,,13503,8619,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,WA,16,19,2.13,0.94,,,2632,1162,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
-2021-07-28,WA,0,999,36.06,14.86,762665,314235,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
+2021-07-28,WA,16,999,36.06,14.86,762665,314235,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,WA,50,999,61.13,22.1,541269,195693,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,WA,70,999,75.91,37.45,212772,104957,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,TAS,95,999,69.85,48.06,,,811,558,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
@@ -316,7 +316,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-28,TAS,25,29,23.29,14.65,,,7945,4998,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,TAS,20,24,16.4,10.27,,,5189,3250,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,TAS,16,19,5.82,3.06,,,1438,756,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
-2021-07-28,TAS,0,999,47,23.02,206900,101319,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
+2021-07-28,TAS,16,999,47,23.02,206900,101319,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,TAS,50,999,68.93,30.19,151678,66423,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-28,TAS,70,999,82.34,46.8,63532,36107,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-29-july-2021.pdf
 2021-07-29,NSW,95,999,72.58,50.42,,,13249,9204,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
@@ -336,7 +336,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-29,NSW,25,29,16.44,9.01,,,99937,54771,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,NSW,20,24,13.57,6.94,,,73310,37492,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,NSW,16,19,6.01,2.62,,,22563,9836,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
-2021-07-29,NSW,0,999,40.16,18.14,2636949,1190942,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
+2021-07-29,NSW,16,999,40.16,18.14,2636949,1190942,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,NSW,50,999,63.97,26.62,1796107,747572,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,NSW,70,999,77.97,41.06,750506,395210,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,VIC,95,999,70.67,47.97,,,9986,6779,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
@@ -356,7 +356,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-29,VIC,25,29,13.42,8.74,,,71823,46776,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,VIC,20,24,10.37,6.38,,,48900,30085,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,VIC,16,19,3.31,1.57,,,10061,4772,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
-2021-07-29,VIC,0,999,41.4,18.48,2238886,999343,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
+2021-07-29,VIC,16,999,41.4,18.48,2238886,999343,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,VIC,50,999,68.25,22.98,1509143,508217,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,VIC,70,999,78.5,38.57,583694,286801,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,QLD,95,999,67.52,46.96,,,6117,4254,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
@@ -376,7 +376,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-29,QLD,25,29,13.82,9.12,,,51199,33787,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,QLD,20,24,11.77,7.08,,,39880,23989,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,QLD,16,19,4.89,2.41,,,12449,6136,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
-2021-07-29,QLD,0,999,36.28,17.62,1492204,724757,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
+2021-07-29,QLD,16,999,36.28,17.62,1492204,724757,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,QLD,50,999,60.48,25.69,1063728,451877,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,QLD,70,999,77.53,41.44,447942,239440,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,ACT,95,999,90.89,63.42,,,579,404,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
@@ -396,7 +396,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-29,ACT,25,29,17.43,11.14,,,5925,3787,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,ACT,20,24,11.56,7.05,,,3772,2300,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,ACT,16,19,4.77,2.48,,,919,478,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
-2021-07-29,ACT,0,999,46.31,21.66,159327,74508,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
+2021-07-29,ACT,16,999,46.31,21.66,159327,74508,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,ACT,50,999,78.14,29.29,99868,37439,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,ACT,70,999,91.47,52.05,36539,20793,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,SA,95,999,72.63,49.88,,,3614,2482,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
@@ -416,7 +416,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-29,SA,25,29,14.9,10.12,,,17544,11916,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,SA,20,24,12.07,7.62,,,13811,8719,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,SA,16,19,5.75,2.92,,,4713,2393,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
-2021-07-29,SA,0,999,40.45,18.49,582657,266357,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
+2021-07-29,SA,16,999,40.45,18.49,582657,266357,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,SA,50,999,62.14,23.4,419049,157819,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,SA,70,999,76.62,36.89,184291,88736,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,NT,95,999,49.48,34.02,,,48,33,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
@@ -436,7 +436,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-29,NT,25,29,29.2,18.93,,,6433,4170,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,NT,20,24,23.72,13.73,,,3817,2210,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,NT,16,19,19.06,9.69,,,2307,1173,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
-2021-07-29,NT,0,999,41.09,23.58,78307,44934,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
+2021-07-29,NT,16,999,41.09,23.58,78307,44934,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,NT,50,999,58.23,27.72,36264,17267,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,NT,70,999,70.31,42.25,8678,5215,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,WA,95,999,69.28,47.8,,,3177,2192,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
@@ -456,7 +456,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-29,WA,25,29,10.26,7.01,,,18967,12959,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,WA,20,24,8.25,5.23,,,13753,8719,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,WA,16,19,2.2,0.97,,,2719,1199,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
-2021-07-29,WA,0,999,36.49,15.38,771680,325350,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
+2021-07-29,WA,16,999,36.49,15.38,771680,325350,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,WA,50,999,61.58,23.01,545227,203738,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,WA,70,999,76.22,38.56,213617,108071,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,TAS,95,999,70.11,48.49,,,814,563,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
@@ -476,7 +476,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-29,TAS,25,29,24.05,14.78,,,8205,5042,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,TAS,20,24,16.81,10.4,,,5319,3291,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,TAS,16,19,6.04,3.14,,,1493,776,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
-2021-07-29,TAS,0,999,47.6,23.54,209540,103595,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
+2021-07-29,TAS,16,999,47.6,23.54,209540,103595,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,TAS,50,999,69.42,30.97,152744,68141,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-29,TAS,70,999,82.61,47.79,63739,36876,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-30-july-2021.pdf
 2021-07-30,NSW,95,999,73,50.85,,,13326,9283,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
@@ -496,7 +496,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-30,NSW,25,29,17.04,9.23,,,103585,56108,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,NSW,20,24,14.13,7.11,,,76335,38411,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,NSW,16,19,6.33,2.72,,,23764,10211,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
-2021-07-30,NSW,0,999,40.95,18.72,2688735,1228845,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
+2021-07-30,NSW,16,999,40.95,18.72,2688735,1228845,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,NSW,50,999,64.74,27.5,1817710,772185,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,NSW,70,999,78.48,41.97,755423,403962,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,VIC,95,999,70.93,48.46,,,10023,6848,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
@@ -516,7 +516,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-30,VIC,25,29,13.68,8.84,,,73214,47311,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,VIC,20,24,10.6,6.46,,,49984,30462,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,VIC,16,19,3.41,1.61,,,10365,4894,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
-2021-07-30,VIC,0,999,41.78,18.94,2259057,1023953,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
+2021-07-30,VIC,16,999,41.78,18.94,2259057,1023953,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,VIC,50,999,68.63,23.8,1517547,526272,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,VIC,70,999,78.72,39.4,585298,292976,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,QLD,95,999,67.73,47.31,,,6136,4286,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
@@ -536,7 +536,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-30,QLD,25,29,14.02,9.28,,,51940,34379,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,QLD,20,24,11.97,7.28,,,40557,24666,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,QLD,16,19,5.02,2.51,,,12780,6390,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
-2021-07-30,QLD,0,999,36.63,18.07,1506591,743107,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
+2021-07-30,QLD,16,999,36.63,18.07,1506591,743107,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,QLD,50,999,60.89,26.41,1070921,464540,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,QLD,70,999,77.79,42.26,449435,244164,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,ACT,95,999,91.05,64.05,,,580,408,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
@@ -556,7 +556,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-30,ACT,25,29,18.01,11.36,,,6122,3861,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,ACT,20,24,12.03,7.22,,,3925,2356,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,ACT,16,19,5.01,2.58,,,965,497,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
-2021-07-30,ACT,0,999,47.16,22.36,162249,76910,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
+2021-07-30,ACT,16,999,47.16,22.36,162249,76910,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,ACT,50,999,78.99,30.38,100949,38828,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,ACT,70,999,91.77,53.1,36657,21211,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,SA,95,999,72.83,50.32,,,3624,2504,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
@@ -576,7 +576,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-30,SA,25,29,15.15,10.23,,,17838,12045,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,SA,20,24,12.3,7.73,,,14074,8845,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,SA,16,19,5.85,2.99,,,4795,2451,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
-2021-07-30,SA,0,999,40.86,18.95,588564,272953,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
+2021-07-30,SA,16,999,40.86,18.95,588564,272953,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,SA,50,999,62.6,24.12,422185,162678,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,SA,70,999,76.92,37.78,184999,90855,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,NT,95,999,49.48,34.02,,,48,33,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
@@ -596,7 +596,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-30,NT,25,29,29.64,19.43,,,6530,4281,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,NT,20,24,24.08,14.09,,,3875,2268,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,NT,16,19,19.4,10.03,,,2348,1214,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
-2021-07-30,NT,0,999,41.64,24.22,79356,46165,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
+2021-07-30,NT,16,999,41.64,24.22,79356,46165,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,NT,50,999,58.8,28.73,36618,17891,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,NT,70,999,70.75,43.19,8733,5331,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,WA,95,999,69.43,48.32,,,3184,2216,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
@@ -616,7 +616,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-30,WA,25,29,10.46,7.07,,,19337,13070,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,WA,20,24,8.45,5.3,,,14087,8836,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,WA,16,19,2.26,0.99,,,2793,1223,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
-2021-07-30,WA,0,999,36.88,15.84,780076,335011,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
+2021-07-30,WA,16,999,36.88,15.84,780076,335011,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,WA,50,999,61.99,23.85,548853,211176,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,WA,70,999,76.44,39.48,214248,110650,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,TAS,95,999,70.28,49.35,,,816,573,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
@@ -636,7 +636,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-30,TAS,25,29,24.44,15.07,,,8338,5141,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,TAS,20,24,17.07,10.61,,,5401,3357,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,TAS,16,19,6.12,3.23,,,1512,798,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
-2021-07-30,TAS,0,999,47.96,24.08,211096,105990,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
+2021-07-30,TAS,16,999,47.96,24.08,211096,105990,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,TAS,50,999,69.76,31.74,153499,69840,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-30,TAS,70,999,82.79,48.71,63879,37580,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/07/covid-19-vaccine-rollout-update-31-july-2021.pdf
 2021-07-31,NSW,95,999,73.18,51.13,,,13359,9334,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
@@ -656,7 +656,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-31,NSW,25,29,17.42,9.45,,,105895,57446,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,NSW,20,24,14.5,7.29,,,78334,39383,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,NSW,16,19,6.56,2.81,,,24627,10549,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
-2021-07-31,NSW,0,999,41.37,19.07,2715978,1252304,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
+2021-07-31,NSW,16,999,41.37,19.07,2715978,1252304,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,NSW,50,999,65.07,27.95,1827152,784658,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,NSW,70,999,78.67,42.34,757246,407532,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,VIC,95,999,71.11,48.74,,,10049,6887,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
@@ -676,7 +676,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-31,VIC,25,29,13.88,8.91,,,74285,47686,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,VIC,20,24,10.76,6.52,,,50739,30745,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,VIC,16,19,3.48,1.62,,,10578,4924,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
-2021-07-31,VIC,0,999,42.04,19.2,2273154,1038227,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
+2021-07-31,VIC,16,999,42.04,19.2,2273154,1038227,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,VIC,50,999,68.86,24.23,1522681,535799,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,VIC,70,999,78.81,39.81,585994,295987,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,QLD,95,999,67.87,47.48,,,6148,4301,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
@@ -696,7 +696,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-31,QLD,25,29,14.17,9.42,,,52495,34898,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,QLD,20,24,12.11,7.45,,,41032,25242,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,QLD,16,19,5.09,2.59,,,12959,6594,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
-2021-07-31,QLD,0,999,36.83,18.32,1514557,753447,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
+2021-07-31,QLD,16,999,36.83,18.32,1514557,753447,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,QLD,50,999,61.07,26.72,1074141,469969,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,QLD,70,999,77.89,42.57,450045,245952,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,ACT,95,999,91.37,64.36,,,582,410,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
@@ -716,7 +716,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-31,ACT,25,29,18.32,11.5,,,6227,3909,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,ACT,20,24,12.21,7.29,,,3984,2378,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,ACT,16,19,5.05,2.68,,,973,516,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
-2021-07-31,ACT,0,999,47.59,22.88,163728,78713,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
+2021-07-31,ACT,16,999,47.59,22.88,163728,78713,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,ACT,50,999,79.41,31.3,101488,40002,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,ACT,70,999,91.94,53.92,36726,21538,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,SA,95,999,72.93,50.46,,,3629,2511,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
@@ -736,7 +736,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-31,SA,25,29,15.32,10.33,,,18039,12163,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,SA,20,24,12.43,7.83,,,14223,8959,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,SA,16,19,5.93,3.05,,,4861,2500,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
-2021-07-31,SA,0,999,41.09,19.16,591855,275925,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
+2021-07-31,SA,16,999,41.09,19.16,591855,275925,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,SA,50,999,62.82,24.33,423615,164047,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,SA,70,999,77,37.93,185186,91230,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,NT,95,999,50.52,34.02,,,49,33,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
@@ -756,7 +756,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-31,NT,25,29,29.84,19.55,,,6574,4307,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,NT,20,24,24.25,14.19,,,3903,2284,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,NT,16,19,19.6,10.16,,,2372,1230,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
-2021-07-31,NT,0,999,41.87,24.43,79787,46553,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
+2021-07-31,NT,16,999,41.87,24.43,79787,46553,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,NT,50,999,58.92,29.06,36698,18099,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,NT,70,999,70.8,43.4,8739,5357,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,WA,95,999,69.49,48.84,,,3187,2240,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
@@ -776,7 +776,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-31,WA,25,29,10.59,7.12,,,19577,13162,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,WA,20,24,8.59,5.34,,,14320,8902,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,WA,16,19,2.33,1,,,2879,1236,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
-2021-07-31,WA,0,999,37.17,16.12,786126,340905,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
+2021-07-31,WA,16,999,37.17,16.12,786126,340905,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,WA,50,999,62.23,24.34,550964,215473,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,WA,70,999,76.55,40.02,214546,112165,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,TAS,95,999,70.37,49.61,,,817,576,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
@@ -796,7 +796,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-07-31,TAS,25,29,24.88,15.28,,,8488,5213,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,TAS,20,24,17.3,10.76,,,5474,3405,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,TAS,16,19,6.26,3.26,,,1547,806,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
-2021-07-31,TAS,0,999,48.35,24.41,212831,107465,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
+2021-07-31,TAS,16,999,48.35,24.41,212831,107465,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,TAS,50,999,70.08,32.17,154212,70787,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-07-31,TAS,70,999,82.93,49.15,63987,37921,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-1-august-2021.pdf
 2021-08-01,NSW,95,999,73.24,51.22,,,13370,9350,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
@@ -816,7 +816,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-01,NSW,25,29,17.62,9.61,,,107110,58418,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,NSW,20,24,14.69,7.44,,,79360,40193,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,NSW,16,19,6.69,2.89,,,25116,10850,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
-2021-08-01,NSW,0,999,41.57,19.28,2729174,1265839,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
+2021-08-01,NSW,16,999,41.57,19.28,2729174,1265839,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,NSW,50,999,65.24,28.16,1831775,790784,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,NSW,70,999,78.76,42.46,758108,408719,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,VIC,95,999,71.16,48.84,,,10056,6902,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
@@ -836,7 +836,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-01,VIC,25,29,14.04,8.97,,,75141,48007,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,VIC,20,24,10.88,6.57,,,51305,30981,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,VIC,16,19,3.55,1.64,,,10791,4985,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
-2021-08-01,VIC,0,999,42.24,19.37,2283955,1047221,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
+2021-08-01,VIC,16,999,42.24,19.37,2283955,1047221,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,VIC,50,999,69.02,24.45,1526285,540695,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,VIC,70,999,78.87,39.94,586383,296976,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,QLD,95,999,67.92,47.54,,,6153,4307,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
@@ -856,7 +856,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-01,QLD,25,29,14.28,9.53,,,52903,35306,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,QLD,20,24,12.21,7.57,,,41370,25649,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,QLD,16,19,5.16,2.66,,,13137,6772,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
-2021-08-01,QLD,0,999,36.97,18.47,1520478,759788,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
+2021-08-01,QLD,16,999,36.97,18.47,1520478,759788,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,QLD,50,999,61.2,26.88,1076356,472836,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,QLD,70,999,77.95,42.72,450357,246812,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,ACT,95,999,91.52,64.52,,,583,411,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
@@ -876,7 +876,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-01,ACT,25,29,18.4,11.51,,,6255,3912,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,ACT,20,24,12.29,7.31,,,4010,2385,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,ACT,16,19,5.07,2.68,,,977,516,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
-2021-08-01,ACT,0,999,47.68,23.06,164048,79341,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
+2021-08-01,ACT,16,999,47.68,23.06,164048,79341,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,ACT,50,999,79.52,31.77,101624,40606,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,ACT,70,999,92.03,54.25,36762,21670,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,SA,95,999,72.97,50.52,,,3631,2514,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
@@ -896,7 +896,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-01,SA,25,29,15.42,10.43,,,18156,12281,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,SA,20,24,12.52,7.91,,,14326,9051,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,SA,16,19,6.01,3.1,,,4926,2541,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
-2021-08-01,SA,0,999,41.23,19.31,593907,278157,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
+2021-08-01,SA,16,999,41.23,19.31,593907,278157,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,SA,50,999,62.94,24.46,424483,164980,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,SA,70,999,77.05,38,185324,91405,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,NT,95,999,50.52,35.05,,,49,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
@@ -916,7 +916,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-01,NT,25,29,30.06,19.6,,,6623,4318,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,NT,20,24,24.44,14.25,,,3933,2293,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,NT,16,19,19.77,10.17,,,2393,1231,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
-2021-08-01,NT,0,999,42.04,24.48,80109,46646,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
+2021-08-01,NT,16,999,42.04,24.48,80109,46646,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,NT,50,999,59,29.1,36743,18121,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,NT,70,999,70.83,43.42,8742,5359,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,WA,95,999,69.65,48.91,,,3194,2243,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
@@ -936,7 +936,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-01,WA,25,29,10.66,7.17,,,19706,13255,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,WA,20,24,8.69,5.38,,,14487,8969,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,WA,16,19,2.38,1.02,,,2941,1260,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
-2021-08-01,WA,0,999,37.4,16.33,790907,345429,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
+2021-08-01,WA,16,999,37.4,16.33,790907,345429,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,WA,50,999,62.38,24.6,552275,217783,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,WA,70,999,76.59,40.1,214659,112380,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,TAS,95,999,70.37,49.61,,,817,576,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
@@ -956,7 +956,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-01,TAS,25,29,25.15,15.45,,,8580,5271,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,TAS,20,24,17.4,10.84,,,5506,3430,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,TAS,16,19,6.33,3.37,,,1564,833,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
-2021-08-01,TAS,0,999,48.53,24.66,213633,108539,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
+2021-08-01,TAS,16,999,48.53,24.66,213633,108539,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,TAS,50,999,70.21,32.42,154498,71342,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-01,TAS,70,999,82.98,49.29,64024,38027,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-2-august-2021.pdf
 2021-08-02,NSW,95,999,73.55,51.69,,,13427,9436,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
@@ -976,7 +976,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-02,NSW,25,29,18.17,9.78,,,110454,59452,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,NSW,20,24,15.23,7.59,,,82277,41004,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,NSW,16,19,7.01,2.97,,,26317,11150,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
-2021-08-02,NSW,0,999,42.23,19.81,2772428,1300394,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
+2021-08-02,NSW,16,999,42.23,19.81,2772428,1300394,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,NSW,50,999,65.89,29.01,1850077,814632,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,NSW,70,999,79.22,43.37,762551,417503,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,VIC,95,999,71.3,49.27,,,10075,6962,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
@@ -996,7 +996,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-02,VIC,25,29,14.28,9.06,,,76426,48488,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,VIC,20,24,11.09,6.65,,,52295,31358,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,VIC,16,19,3.64,1.69,,,11064,5137,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
-2021-08-02,VIC,0,999,42.58,19.85,2302523,1073291,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
+2021-08-02,VIC,16,999,42.58,19.85,2302523,1073291,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,VIC,50,999,69.37,25.34,1533962,560346,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,VIC,70,999,79.07,40.82,587903,303525,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,QLD,95,999,68.22,47.88,,,6180,4337,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
@@ -1016,7 +1016,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-02,QLD,25,29,14.44,9.61,,,53496,35602,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,QLD,20,24,12.35,7.66,,,41845,25954,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,QLD,16,19,5.25,2.71,,,13366,6899,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
-2021-08-02,QLD,0,999,37.26,18.82,1532546,773840,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
+2021-08-02,QLD,16,999,37.26,18.82,1532546,773840,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,QLD,50,999,61.58,27.53,1083085,484261,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,QLD,70,999,78.21,43.5,451879,251334,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,ACT,95,999,91.84,64.84,,,585,413,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
@@ -1036,7 +1036,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-02,ACT,25,29,19.03,11.77,,,6469,4001,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,ACT,20,24,12.82,7.53,,,4183,2457,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,ACT,16,19,5.37,2.79,,,1035,538,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
-2021-08-02,ACT,0,999,48.88,23.92,168170,82284,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
+2021-08-02,ACT,16,999,48.88,23.92,168170,82284,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,ACT,50,999,80.66,32.76,103083,41873,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,ACT,70,999,92.32,54.92,36878,21937,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,SA,95,999,73.23,50.94,,,3644,2535,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
@@ -1056,7 +1056,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-02,SA,25,29,15.72,10.54,,,18510,12410,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,SA,20,24,12.76,8.01,,,14601,9165,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,SA,16,19,6.12,3.19,,,5016,2615,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
-2021-08-02,SA,0,999,41.64,19.75,599826,284507,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
+2021-08-02,SA,16,999,41.64,19.75,599826,284507,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,SA,50,999,63.42,25.16,427690,169701,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,SA,70,999,77.36,38.84,186063,93411,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,NT,95,999,50.52,35.05,,,49,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
@@ -1076,7 +1076,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-02,NT,25,29,30.24,19.72,,,6662,4345,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,NT,20,24,24.61,14.4,,,3961,2318,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,NT,16,19,19.91,10.25,,,2410,1241,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
-2021-08-02,NT,0,999,42.16,24.62,80352,46911,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
+2021-08-02,NT,16,999,42.16,24.62,80352,46911,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,NT,50,999,59.1,29.26,36808,18224,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,NT,70,999,70.9,43.55,8751,5375,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,WA,95,999,69.91,49.28,,,3206,2260,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
@@ -1096,7 +1096,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-02,WA,25,29,10.78,7.24,,,19928,13384,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,WA,20,24,8.77,5.45,,,14620,9086,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,WA,16,19,2.41,1.05,,,2978,1298,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
-2021-08-02,WA,0,999,37.67,16.83,796736,356046,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
+2021-08-02,WA,16,999,37.67,16.83,796736,356046,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,WA,50,999,62.71,25.49,555240,225703,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,WA,70,999,76.85,40.99,215402,114893,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,TAS,95,999,70.54,49.78,,,819,578,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
@@ -1116,7 +1116,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-02,TAS,25,29,25.39,15.82,,,8662,5397,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,TAS,20,24,17.62,11.05,,,5575,3496,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,TAS,16,19,6.44,3.49,,,1592,862,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
-2021-08-02,TAS,0,999,48.81,25.08,214854,110385,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
+2021-08-02,TAS,16,999,48.81,25.08,214854,110385,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,TAS,50,999,70.49,32.91,155093,72403,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-02,TAS,70,999,83.14,49.71,64150,38351,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-3-august-2021.pdf
 2021-08-03,NSW,95,999,73.84,52.19,,,13479,9527,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
@@ -1136,7 +1136,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-03,NSW,25,29,18.89,10.01,,,114831,60850,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,NSW,20,24,15.91,7.8,,,85951,42138,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,NSW,16,19,7.42,3.06,,,27856,11488,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
-2021-08-03,NSW,0,999,43.04,20.44,2825917,1342211,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
+2021-08-03,NSW,16,999,43.04,20.44,2825917,1342211,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,NSW,50,999,66.63,30,1870957,842233,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,NSW,70,999,79.74,44.39,767555,427347,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,VIC,95,999,71.59,49.69,,,10116,7022,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
@@ -1156,7 +1156,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-03,VIC,25,29,14.52,9.14,,,77710,48917,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,VIC,20,24,11.28,6.72,,,53191,31688,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,VIC,16,19,3.73,1.72,,,11338,5228,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
-2021-08-03,VIC,0,999,42.92,20.29,2320875,1097386,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
+2021-08-03,VIC,16,999,42.92,20.29,2320875,1097386,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,VIC,50,999,69.73,26.19,1541840,579219,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,VIC,70,999,79.3,41.69,589628,309982,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,QLD,95,999,68.43,48.36,,,6199,4381,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
@@ -1176,7 +1176,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-03,QLD,25,29,14.67,9.78,,,54348,36232,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,QLD,20,24,12.55,7.83,,,42522,26530,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,QLD,16,19,5.36,2.79,,,13646,7103,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
-2021-08-03,QLD,0,999,37.68,19.34,1549491,795568,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
+2021-08-03,QLD,16,999,37.68,19.34,1549491,795568,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,QLD,50,999,62.1,28.46,1092264,500576,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,QLD,70,999,78.57,44.54,453931,257363,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,ACT,95,999,92.31,65.15,,,588,415,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
@@ -1196,7 +1196,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-03,ACT,25,29,19.41,11.91,,,6598,4048,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,ACT,20,24,13.09,7.64,,,4271,2493,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,ACT,16,19,5.52,2.82,,,1064,543,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
-2021-08-03,ACT,0,999,49.4,24.43,169974,84043,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
+2021-08-03,ACT,16,999,49.4,24.43,169974,84043,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,ACT,50,999,81.21,33.64,103792,42993,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,ACT,70,999,92.61,55.9,36994,22331,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,SA,95,999,73.47,51.31,,,3656,2553,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
@@ -1216,7 +1216,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-03,SA,25,29,15.98,10.67,,,18816,12563,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,SA,20,24,12.98,8.12,,,14852,9291,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,SA,16,19,6.25,3.3,,,5123,2705,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
-2021-08-03,SA,0,999,42.07,20.23,605951,291436,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
+2021-08-03,SA,16,999,42.07,20.23,605951,291436,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,SA,50,999,63.92,25.94,431068,174943,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,SA,70,999,77.7,39.68,186870,95439,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,NT,95,999,50.52,35.05,,,49,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
@@ -1236,7 +1236,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-03,NT,25,29,30.53,20.07,,,6726,4422,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,NT,20,24,24.92,14.65,,,4011,2358,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,NT,16,19,20.17,10.48,,,2441,1268,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
-2021-08-03,NT,0,999,42.57,25.03,81129,47709,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
+2021-08-03,NT,16,999,42.57,25.03,81129,47709,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,NT,50,999,59.45,29.92,37026,18633,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,NT,70,999,71.09,44.15,8775,5450,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,WA,95,999,70.04,49.61,,,3212,2275,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
@@ -1256,7 +1256,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-03,WA,25,29,10.91,7.31,,,20169,13513,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,WA,20,24,8.88,5.54,,,14804,9236,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,WA,16,19,2.45,1.08,,,3028,1335,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
-2021-08-03,WA,0,999,38,17.39,803715,367691,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
+2021-08-03,WA,16,999,38,17.39,803715,367691,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,WA,50,999,63.06,26.39,558358,233635,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,WA,70,999,77.07,41.88,216003,117389,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,TAS,95,999,71.15,50.47,,,826,586,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
@@ -1276,7 +1276,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-03,TAS,25,29,25.67,16.2,,,8757,5527,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,TAS,20,24,17.85,11.29,,,5648,3572,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,TAS,16,19,6.54,3.57,,,1616,882,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
-2021-08-03,TAS,0,999,49.2,25.7,216586,113118,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
+2021-08-03,TAS,16,999,49.2,25.7,216586,113118,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,TAS,50,999,70.87,33.8,155929,74375,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-03,TAS,70,999,83.34,50.75,64301,39156,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-4-august-2021.pdf
 2021-08-04,NSW,95,999,74.19,52.7,,,13543,9620,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
@@ -1296,7 +1296,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-04,NSW,25,29,19.55,10.22,,,118843,62126,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,NSW,20,24,16.54,7.99,,,89355,43165,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,NSW,16,19,7.8,3.15,,,29283,11826,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
-2021-08-04,NSW,0,999,43.78,21.04,2874425,1381481,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
+2021-08-04,NSW,16,999,43.78,21.04,2874425,1381481,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,NSW,50,999,67.35,30.96,1891054,869282,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,NSW,70,999,80.28,45.45,772789,437461,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,VIC,95,999,71.82,50.1,,,10149,7080,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
@@ -1316,7 +1316,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-04,VIC,25,29,14.78,9.24,,,79102,49452,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,VIC,20,24,11.48,6.81,,,54134,32113,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,VIC,16,19,3.83,1.76,,,11642,5350,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
-2021-08-04,VIC,0,999,43.26,20.8,2339301,1124519,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
+2021-08-04,VIC,16,999,43.26,20.8,2339301,1124519,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,VIC,50,999,70.08,27.13,1549648,599861,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,VIC,70,999,79.56,42.66,591515,317192,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,QLD,95,999,68.62,48.87,,,6216,4427,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
@@ -1336,7 +1336,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-04,QLD,25,29,14.96,9.99,,,55422,37010,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,QLD,20,24,12.79,8.04,,,43336,27241,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,QLD,16,19,5.51,2.92,,,14028,7434,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
-2021-08-04,QLD,0,999,38.19,19.95,1570498,820439,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
+2021-08-04,QLD,16,999,38.19,19.95,1570498,820439,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,QLD,50,999,62.73,29.48,1103364,518525,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,QLD,70,999,78.97,45.67,456285,263871,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,ACT,95,999,92.62,66.25,,,590,422,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
@@ -1356,7 +1356,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-04,ACT,25,29,19.62,12.02,,,6669,4086,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,ACT,20,24,13.26,7.76,,,4326,2532,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,ACT,16,19,5.63,2.87,,,1085,553,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
-2021-08-04,ACT,0,999,49.65,24.77,170831,85228,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
+2021-08-04,ACT,16,999,49.65,24.77,170831,85228,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,ACT,50,999,81.51,34.31,104177,43850,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,ACT,70,999,92.88,56.77,37101,22676,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,SA,95,999,73.77,51.77,,,3671,2576,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
@@ -1376,7 +1376,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-04,SA,25,29,16.26,10.84,,,19145,12764,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,SA,20,24,13.21,8.27,,,15116,9463,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,SA,16,19,6.39,3.4,,,5238,2787,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
-2021-08-04,SA,0,999,42.53,20.8,612645,299590,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
+2021-08-04,SA,16,999,42.53,20.8,612645,299590,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,SA,50,999,64.49,26.85,434905,181105,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,SA,70,999,78.1,40.72,187843,97939,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,NT,95,999,50.52,35.05,,,49,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
@@ -1396,7 +1396,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-04,NT,25,29,31.05,20.54,,,6841,4525,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,NT,20,24,25.37,15.12,,,4083,2433,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,NT,16,19,20.43,10.88,,,2473,1317,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
-2021-08-04,NT,0,999,43.04,25.7,82018,48979,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
+2021-08-04,NT,16,999,43.04,25.7,82018,48979,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,NT,50,999,59.88,30.74,37295,19147,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,NT,70,999,71.41,44.93,8814,5546,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,WA,95,999,70.28,50.02,,,3223,2294,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
@@ -1416,7 +1416,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-04,WA,25,29,11.06,7.39,,,20446,13661,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,WA,20,24,9.02,5.62,,,15037,9369,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,WA,16,19,2.52,1.1,,,3114,1359,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
-2021-08-04,WA,0,999,38.39,17.9,811909,378575,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
+2021-08-04,WA,16,999,38.39,17.9,811909,378575,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,WA,50,999,63.47,27.2,561979,240824,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,WA,70,999,77.32,42.75,216707,119819,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,TAS,95,999,71.4,50.82,,,829,590,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
@@ -1436,7 +1436,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-04,TAS,25,29,26.08,16.57,,,8897,5653,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,TAS,20,24,18.06,11.53,,,5714,3648,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,TAS,16,19,6.67,3.69,,,1648,912,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
-2021-08-04,TAS,0,999,49.58,26.25,218238,115541,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
+2021-08-04,TAS,16,999,49.58,26.25,218238,115541,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,TAS,50,999,71.22,34.54,156710,75998,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-04,TAS,70,999,83.55,51.41,64463,39662,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-5-august-2021.pdf
 2021-08-05,NSW,95,999,74.57,53.28,,,13613,9726,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
@@ -1456,7 +1456,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-05,NSW,25,29,20.32,10.46,,,123523,63585,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,NSW,20,24,17.31,8.19,,,93514,44245,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,NSW,16,19,8.26,3.25,,,31010,12201,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
-2021-08-05,NSW,0,999,44.66,21.68,2931990,1423185,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
+2021-08-05,NSW,16,999,44.66,21.68,2931990,1423185,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,NSW,50,999,68.14,31.97,1913359,897590,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,NSW,70,999,80.83,46.45,778091,447111,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,VIC,95,999,72.05,50.5,,,10181,7136,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
@@ -1476,7 +1476,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-05,VIC,25,29,15.07,9.34,,,80654,49987,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,VIC,20,24,11.7,6.89,,,55171,32490,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,VIC,16,19,3.92,1.79,,,11915,5441,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
-2021-08-05,VIC,0,999,43.62,21.31,2358825,1152530,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
+2021-08-05,VIC,16,999,43.62,21.31,2358825,1152530,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,VIC,50,999,70.44,28.09,1557642,621167,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,VIC,70,999,79.8,43.63,593356,324390,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,QLD,95,999,68.89,49.34,,,6241,4470,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
@@ -1496,7 +1496,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-05,QLD,25,29,15.29,10.19,,,56645,37751,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,QLD,20,24,13.09,8.26,,,44352,27987,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,QLD,16,19,5.67,3.05,,,14435,7765,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
-2021-08-05,QLD,0,999,38.74,20.55,1593427,845211,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
+2021-08-05,QLD,16,999,38.74,20.55,1593427,845211,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,QLD,50,999,63.41,30.52,1115216,536744,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,QLD,70,999,79.41,46.79,458832,270349,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,ACT,95,999,92.94,66.72,,,592,425,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
@@ -1516,7 +1516,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-05,ACT,25,29,19.84,12.07,,,6744,4103,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,ACT,20,24,13.41,7.81,,,4375,2548,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,ACT,16,19,5.73,2.89,,,1104,557,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
-2021-08-05,ACT,0,999,49.86,25.07,171540,86247,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
+2021-08-05,ACT,16,999,49.86,25.07,171540,86247,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,ACT,50,999,81.76,34.96,104493,44683,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,ACT,70,999,93.11,57.6,37194,23009,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,SA,95,999,73.93,52.03,,,3679,2589,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
@@ -1536,7 +1536,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-05,SA,25,29,16.55,10.97,,,19487,12917,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,SA,20,24,13.42,8.39,,,15356,9600,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,SA,16,19,6.52,3.47,,,5344,2844,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
-2021-08-05,SA,0,999,42.96,21.32,618807,307094,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
+2021-08-05,SA,16,999,42.96,21.32,618807,307094,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,SA,50,999,65.01,27.7,438445,186825,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,SA,70,999,78.45,41.66,188687,100191,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,NT,95,999,50.52,35.05,,,49,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
@@ -1556,7 +1556,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-05,NT,25,29,31.6,21.03,,,6962,4633,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,NT,20,24,25.9,15.55,,,4168,2503,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,NT,16,19,20.93,11.2,,,2533,1356,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
-2021-08-05,NT,0,999,43.63,26.28,83141,50089,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
+2021-08-05,NT,16,999,43.63,26.28,83141,50089,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,NT,50,999,60.44,31.57,37643,19661,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,NT,70,999,71.85,45.91,8868,5667,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,WA,95,999,70.41,50.59,,,3229,2320,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
@@ -1576,7 +1576,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-05,WA,25,29,11.27,7.48,,,20834,13828,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,WA,20,24,9.19,5.7,,,15321,9502,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,WA,16,19,2.6,1.13,,,3213,1396,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
-2021-08-05,WA,0,999,38.84,18.46,821478,390391,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
+2021-08-05,WA,16,999,38.84,18.46,821478,390391,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,WA,50,999,63.97,28.15,566351,249260,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,WA,70,999,77.61,43.83,217530,122834,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,TAS,95,999,71.49,51.34,,,830,596,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
@@ -1596,7 +1596,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-05,TAS,25,29,26.67,16.88,,,9098,5759,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,TAS,20,24,18.42,11.76,,,5828,3721,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,TAS,16,19,6.95,3.76,,,1718,929,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
-2021-08-05,TAS,0,999,50.08,26.76,220446,117799,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
+2021-08-05,TAS,16,999,50.08,26.76,220446,117799,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,TAS,50,999,71.58,35.19,157496,77434,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-05,TAS,70,999,83.71,52.04,64588,40150,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-6-august-2021.pdf
 2021-08-06,NSW,95,999,75.07,53.73,,,13704,9808,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
@@ -1616,7 +1616,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-06,NSW,25,29,21.09,10.69,,,128204,64984,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,NSW,20,24,18.08,8.39,,,97674,45326,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,NSW,16,19,8.73,3.36,,,32774,12614,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
-2021-08-06,NSW,0,999,45.46,22.29,2984776,1463495,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
+2021-08-06,NSW,16,999,45.46,22.29,2984776,1463495,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,NSW,50,999,68.86,32.9,1933385,923858,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,NSW,70,999,81.35,47.33,783068,455598,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,VIC,95,999,72.18,50.87,,,10200,7188,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
@@ -1636,7 +1636,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-06,VIC,25,29,15.39,9.45,,,82366,50576,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,VIC,20,24,11.95,6.99,,,56350,32961,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,VIC,16,19,4.05,1.84,,,12310,5593,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
-2021-08-06,VIC,0,999,44,21.87,2379619,1182570,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
+2021-08-06,VIC,16,999,44,21.87,2379619,1182570,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,VIC,50,999,70.82,29.08,1565885,643067,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,VIC,70,999,80.03,44.45,595003,330492,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,QLD,95,999,69.31,49.97,,,6279,4527,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
@@ -1656,7 +1656,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-06,QLD,25,29,15.68,10.38,,,58089,38455,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,QLD,20,24,13.44,8.46,,,45538,28665,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,QLD,16,19,5.87,3.15,,,14944,8020,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
-2021-08-06,QLD,0,999,39.34,21.12,1618162,868777,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
+2021-08-06,QLD,16,999,39.34,21.12,1618162,868777,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,QLD,50,999,64.09,31.49,1127312,553882,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,QLD,70,999,79.83,47.79,461230,276086,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,ACT,95,999,93.09,66.88,,,593,426,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
@@ -1676,7 +1676,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-06,ACT,25,29,20.35,12.22,,,6917,4154,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,ACT,20,24,13.76,7.89,,,4489,2574,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,ACT,16,19,5.98,2.92,,,1152,563,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
-2021-08-06,ACT,0,999,50.44,25.64,173549,88212,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
+2021-08-06,ACT,16,999,50.44,25.64,173549,88212,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,ACT,50,999,82.32,36.11,105211,46144,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,ACT,70,999,93.4,58.82,37308,23496,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,SA,95,999,74.12,52.51,,,3688,2613,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
@@ -1696,7 +1696,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-06,SA,25,29,16.8,11.13,,,19781,13105,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,SA,20,24,13.63,8.52,,,15596,9749,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,SA,16,19,6.64,3.57,,,5443,2926,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
-2021-08-06,SA,0,999,43.37,21.83,624716,314398,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
+2021-08-06,SA,16,999,43.37,21.83,624716,314398,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,SA,50,999,65.49,28.5,441666,192215,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,SA,70,999,78.75,42.53,189395,102286,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,NT,95,999,49.48,35.05,,,48,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
@@ -1716,7 +1716,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-06,NT,25,29,32.15,21.34,,,7083,4701,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,NT,20,24,26.44,15.82,,,4255,2546,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,NT,16,19,21.42,11.54,,,2592,1397,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
-2021-08-06,NT,0,999,44.16,26.83,84153,51123,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
+2021-08-06,NT,16,999,44.16,26.83,84153,51123,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,NT,50,999,60.96,32.44,37963,20204,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,NT,70,999,72.22,46.5,8914,5739,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,WA,95,999,70.58,51.16,,,3237,2346,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
@@ -1736,7 +1736,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-06,WA,25,29,11.45,7.58,,,21167,14013,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,WA,20,24,9.37,5.8,,,15621,9669,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,WA,16,19,2.67,1.17,,,3299,1446,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
-2021-08-06,WA,0,999,39.22,18.97,829564,401300,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
+2021-08-06,WA,16,999,39.22,18.97,829564,401300,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,WA,50,999,64.37,29.04,569942,257094,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,WA,70,999,77.86,44.66,218223,125167,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,TAS,95,999,71.58,51.59,,,831,599,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
@@ -1756,7 +1756,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-06,TAS,25,29,27.1,17.14,,,9245,5847,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,TAS,20,24,18.67,11.89,,,5907,3762,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,TAS,16,19,7.09,3.83,,,1752,947,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
-2021-08-06,TAS,0,999,50.48,27.2,222184,119730,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
+2021-08-06,TAS,16,999,50.48,27.2,222184,119730,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,TAS,50,999,71.93,35.79,158267,78742,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-06,TAS,70,999,83.88,52.6,64714,40585,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-7-august-2021.pdf
 2021-08-07,NSW,95,999,75.18,53.96,,,13724,9850,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
@@ -1776,7 +1776,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-07,NSW,25,29,21.6,11.02,,,131304,66990,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,NSW,20,24,18.57,8.68,,,100321,46892,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,NSW,16,19,9.03,3.52,,,33900,13215,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
-2021-08-07,NSW,0,999,45.94,22.87,3016441,1501249,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
+2021-08-07,NSW,16,999,45.94,22.87,3016441,1501249,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,NSW,50,999,69.23,33.54,1943796,941614,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,NSW,70,999,81.55,47.78,784972,459886,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,VIC,95,999,72.3,51.08,,,10217,7218,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
@@ -1796,7 +1796,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-07,VIC,25,29,15.61,9.56,,,83544,51164,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,VIC,20,24,12.11,7.09,,,57105,33433,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,VIC,16,19,4.14,1.89,,,12584,5745,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
-2021-08-07,VIC,0,999,44.25,22.22,2392900,1201714,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
+2021-08-07,VIC,16,999,44.25,22.22,2392900,1201714,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,VIC,50,999,71.03,29.63,1570626,655145,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,VIC,70,999,80.14,44.82,595850,333259,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,QLD,95,999,69.41,50.24,,,6288,4551,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
@@ -1816,7 +1816,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-07,QLD,25,29,15.87,10.51,,,58793,38936,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,QLD,20,24,13.63,8.6,,,46182,29139,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,QLD,16,19,5.97,3.24,,,15199,8249,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
-2021-08-07,QLD,0,999,39.66,21.41,1631002,880512,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
+2021-08-07,QLD,16,999,39.66,21.41,1631002,880512,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,QLD,50,999,64.4,31.89,1132718,560821,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,QLD,70,999,79.97,48.11,462067,277964,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,ACT,95,999,93.25,67.19,,,594,428,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
@@ -1836,7 +1836,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-07,ACT,25,29,20.75,12.3,,,7053,4181,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,ACT,20,24,14.03,7.95,,,4577,2594,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,ACT,16,19,6.12,2.96,,,1179,570,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
-2021-08-07,ACT,0,999,50.85,26.08,174961,89739,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
+2021-08-07,ACT,16,999,50.85,26.08,174961,89739,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,ACT,50,999,82.67,36.99,105660,47271,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,ACT,70,999,93.55,59.34,37369,23704,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,SA,95,999,74.2,52.63,,,3692,2619,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
@@ -1856,7 +1856,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-07,SA,25,29,16.99,11.26,,,20005,13258,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,SA,20,24,13.8,8.65,,,15791,9898,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,SA,16,19,6.76,3.64,,,5541,2984,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
-2021-08-07,SA,0,999,43.63,22.13,628406,318824,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
+2021-08-07,SA,16,999,43.63,22.13,628406,318824,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,SA,50,999,65.75,28.89,443431,194800,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,SA,70,999,78.86,42.8,189669,102930,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,NT,95,999,49.48,35.05,,,48,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
@@ -1876,7 +1876,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-07,NT,25,29,32.4,21.53,,,7138,4743,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,NT,20,24,26.62,16.04,,,4284,2581,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,NT,16,19,21.54,11.82,,,2607,1431,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
-2021-08-07,NT,0,999,44.38,27.18,84574,51794,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
+2021-08-07,NT,16,999,44.38,27.18,84574,51794,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,NT,50,999,61.13,32.98,38070,20538,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,NT,70,999,72.36,46.88,8931,5786,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,WA,95,999,70.72,51.53,,,3243,2363,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
@@ -1896,7 +1896,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-07,WA,25,29,11.56,7.64,,,21370,14124,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,WA,20,24,9.46,5.85,,,15771,9752,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,WA,16,19,2.72,1.18,,,3361,1458,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
-2021-08-07,WA,0,999,39.49,19.3,835216,408162,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
+2021-08-07,WA,16,999,39.49,19.3,835216,408162,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,WA,50,999,64.6,29.57,571956,261813,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,WA,70,999,77.96,45.13,218511,126500,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,TAS,95,999,71.75,52.02,,,833,604,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
@@ -1916,7 +1916,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-07,TAS,25,29,27.51,17.34,,,9385,5916,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,TAS,20,24,18.92,12.02,,,5986,3803,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,TAS,16,19,7.22,3.89,,,1784,961,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
-2021-08-07,TAS,0,999,50.88,27.67,223977,121799,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
+2021-08-07,TAS,16,999,50.88,27.67,223977,121799,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,TAS,50,999,72.26,36.47,158990,80251,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-07,TAS,70,999,84.04,53.06,64840,40942,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-8-august-2021.pdf
 2021-08-08,NSW,95,999,75.27,54.02,,,13741,9861,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
@@ -1936,7 +1936,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-08,NSW,25,29,21.93,11.12,,,133310,67597,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,NSW,20,24,18.91,8.76,,,102158,47324,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,NSW,16,19,9.26,3.56,,,34764,13365,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
-2021-08-08,NSW,0,999,46.2,23.01,3033491,1510648,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
+2021-08-08,NSW,16,999,46.2,23.01,3033491,1510648,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,NSW,50,999,69.39,33.71,1948415,946567,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,NSW,70,999,81.63,47.88,785780,460872,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,VIC,95,999,72.37,51.19,,,10227,7234,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
@@ -1956,7 +1956,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-08,VIC,25,29,15.83,9.65,,,84721,51646,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,VIC,20,24,12.28,7.17,,,57906,33810,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,VIC,16,19,4.22,1.93,,,12827,5866,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
-2021-08-08,VIC,0,999,44.47,22.47,2404557,1215296,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
+2021-08-08,VIC,16,999,44.47,22.47,2404557,1215296,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,VIC,50,999,71.19,29.97,1574103,662597,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,VIC,70,999,80.2,45.01,596294,334651,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,QLD,95,999,69.52,50.31,,,6298,4558,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
@@ -1976,7 +1976,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-08,QLD,25,29,16.05,10.6,,,59460,39270,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,QLD,20,24,13.77,8.7,,,46656,29478,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,QLD,16,19,6.08,3.29,,,15479,8376,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
-2021-08-08,QLD,0,999,39.88,21.57,1640384,887301,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
+2021-08-08,QLD,16,999,39.88,21.57,1640384,887301,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,QLD,50,999,64.6,32.09,1136226,564332,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,QLD,70,999,80.05,48.24,462485,278710,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,ACT,95,999,93.41,67.35,,,595,429,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
@@ -1996,7 +1996,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-08,ACT,25,29,20.95,12.33,,,7121,4191,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,ACT,20,24,14.16,8,,,4620,2610,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,ACT,16,19,6.2,2.99,,,1195,576,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
-2021-08-08,ACT,0,999,50.99,26.38,175425,90765,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
+2021-08-08,ACT,16,999,50.99,26.38,175425,90765,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,ACT,50,999,82.79,37.63,105807,48087,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,ACT,70,999,93.66,59.65,37414,23826,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,SA,95,999,74.36,52.69,,,3700,2622,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
@@ -2016,7 +2016,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-08,SA,25,29,17.14,11.38,,,20181,13399,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,SA,20,24,13.92,8.74,,,15928,10001,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,SA,16,19,6.86,3.69,,,5623,3025,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
-2021-08-08,SA,0,999,43.82,22.32,631126,321501,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
+2021-08-08,SA,16,999,43.82,22.32,631126,321501,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,SA,50,999,65.93,29.08,444628,196080,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,SA,70,999,78.94,42.85,189869,103070,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,NT,95,999,49.48,35.05,,,48,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
@@ -2036,7 +2036,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-08,NT,25,29,32.52,21.6,,,7164,4759,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,NT,20,24,26.71,16.07,,,4299,2586,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,NT,16,19,21.57,11.86,,,2611,1435,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
-2021-08-08,NT,0,999,44.48,27.23,84762,51884,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
+2021-08-08,NT,16,999,44.48,27.23,84762,51884,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,NT,50,999,61.19,33.02,38112,20564,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,NT,70,999,72.4,46.91,8936,5790,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,WA,95,999,70.96,51.68,,,3254,2370,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
@@ -2056,7 +2056,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-08,WA,25,29,11.65,7.7,,,21537,14234,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,WA,20,24,9.58,5.92,,,15971,9869,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,WA,16,19,2.76,1.2,,,3411,1483,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
-2021-08-08,WA,0,999,39.69,19.56,839402,413694,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
+2021-08-08,WA,16,999,39.69,19.56,839402,413694,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,WA,50,999,64.7,29.88,572865,264510,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,WA,70,999,78,45.21,218625,126720,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,TAS,95,999,71.83,52.28,,,834,607,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
@@ -2076,7 +2076,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-08,TAS,25,29,27.78,17.59,,,9477,6001,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,TAS,20,24,19.07,12.15,,,6034,3844,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,TAS,16,19,7.33,3.99,,,1811,986,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
-2021-08-08,TAS,0,999,51.08,27.97,224856,123114,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
+2021-08-08,TAS,16,999,51.08,27.97,224856,123114,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,TAS,50,999,72.4,36.8,159299,80968,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-08,TAS,70,999,84.09,53.24,64880,41080,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-9-august-2021.pdf
 2021-08-09,NSW,95,999,75.73,54.42,,,13825,9934,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
@@ -2096,7 +2096,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-09,NSW,25,29,22.72,11.32,,,138113,68813,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,NSW,20,24,19.72,8.93,,,106534,48243,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,NSW,16,19,9.89,3.65,,,37129,13703,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
-2021-08-09,NSW,0,999,46.99,23.59,3085235,1548545,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
+2021-08-09,NSW,16,999,46.99,23.59,3085235,1548545,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,NSW,50,999,70.05,34.63,1966885,972461,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,NSW,70,999,82.08,48.7,790070,468768,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,VIC,95,999,72.53,51.62,,,10249,7294,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
@@ -2116,7 +2116,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-09,VIC,25,29,16.26,9.78,,,87022,52342,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,VIC,20,24,12.64,7.29,,,59604,34376,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,VIC,16,19,4.38,1.98,,,13313,6018,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
-2021-08-09,VIC,0,999,44.89,23.03,2427550,1245389,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
+2021-08-09,VIC,16,999,44.89,23.03,2427550,1245389,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,VIC,50,999,71.54,30.97,1581978,684871,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,VIC,70,999,80.41,45.86,597894,340986,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,QLD,95,999,69.75,50.58,,,6319,4582,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
@@ -2136,7 +2136,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-09,QLD,25,29,16.29,10.7,,,60349,39640,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,QLD,20,24,14.01,8.81,,,47469,29850,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,QLD,16,19,6.2,3.35,,,15785,8529,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
-2021-08-09,QLD,0,999,40.24,21.95,1655238,902692,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
+2021-08-09,QLD,16,999,40.24,21.95,1655238,902692,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,QLD,50,999,65.01,32.77,1143439,576429,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,QLD,70,999,80.32,48.88,464063,282431,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,ACT,95,999,93.41,67.35,,,595,429,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
@@ -2156,7 +2156,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-09,ACT,25,29,21.67,12.57,,,7366,4273,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,ACT,20,24,14.77,8.18,,,4819,2669,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,ACT,16,19,6.54,3.09,,,1260,595,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
-2021-08-09,ACT,0,999,51.88,27.14,178484,93380,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
+2021-08-09,ACT,16,999,51.88,27.14,178484,93380,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,ACT,50,999,83.54,38.81,106766,49599,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,ACT,70,999,93.85,60.26,37490,24072,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,SA,95,999,74.64,53.07,,,3714,2641,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
@@ -2176,7 +2176,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-09,SA,25,29,17.5,11.52,,,20605,13564,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,SA,20,24,14.23,8.89,,,16283,10172,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,SA,16,19,7.03,3.79,,,5762,3107,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
-2021-08-09,SA,0,999,44.21,22.79,636881,328327,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
+2021-08-09,SA,16,999,44.21,22.79,636881,328327,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,SA,50,999,66.34,29.8,447413,201000,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,SA,70,999,79.22,43.53,190537,104692,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,NT,95,999,49.48,35.05,,,48,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
@@ -2196,7 +2196,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-09,NT,25,29,33.15,21.84,,,7303,4812,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,NT,20,24,27.35,16.32,,,4402,2627,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,NT,16,19,21.99,12.1,,,2661,1464,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
-2021-08-09,NT,0,999,45.05,27.69,85850,52765,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
+2021-08-09,NT,16,999,45.05,27.69,85850,52765,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,NT,50,999,61.58,33.81,38355,21056,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,NT,70,999,72.59,47.65,8960,5882,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,WA,95,999,71.17,52.03,,,3264,2386,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
@@ -2216,7 +2216,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-09,WA,25,29,11.79,7.78,,,21795,14382,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,WA,20,24,9.71,6,,,16187,10003,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,WA,16,19,2.82,1.25,,,3485,1545,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
-2021-08-09,WA,0,999,39.98,20.13,845629,425656,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
+2021-08-09,WA,16,999,39.98,20.13,845629,425656,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,WA,50,999,65.05,30.96,575941,274072,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,WA,70,999,78.27,46.19,219374,129454,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,TAS,95,999,72.18,52.8,,,838,613,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
@@ -2236,7 +2236,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-09,TAS,25,29,28.08,17.98,,,9579,6134,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,TAS,20,24,19.41,12.39,,,6142,3920,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,TAS,16,19,7.48,4.14,,,1849,1023,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
-2021-08-09,TAS,0,999,51.43,28.64,226367,126053,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
+2021-08-09,TAS,16,999,51.43,28.64,226367,126053,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,TAS,50,999,72.71,37.7,159983,82948,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-09,TAS,70,999,84.32,54.16,65056,41788,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-10-august-2021.pdf
 2021-08-10,NSW,95,999,76.1,54.85,,,13892,10013,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
@@ -2256,7 +2256,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-10,NSW,25,29,23.83,11.62,,,144860,70637,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,NSW,20,24,20.78,9.21,,,112260,49755,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,NSW,16,19,11.47,3.77,,,43061,14153,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
-2021-08-10,NSW,0,999,48.06,24.36,3155892,1599438,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
+2021-08-10,NSW,16,999,48.06,24.36,3155892,1599438,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,NSW,50,999,70.87,35.8,1989747,1005278,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,NSW,70,999,82.59,49.72,795021,478582,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,VIC,95,999,72.75,51.96,,,10280,7342,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
@@ -2276,7 +2276,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-10,VIC,25,29,16.78,9.9,,,89805,52984,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,VIC,20,24,13.08,7.4,,,61679,34895,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,VIC,16,19,4.58,2.03,,,13921,6170,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
-2021-08-10,VIC,0,999,45.35,23.59,2452203,1275621,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
+2021-08-10,VIC,16,999,45.35,23.59,2452203,1275621,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,VIC,50,999,71.91,32.01,1590061,707781,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,VIC,70,999,80.66,46.74,599712,347554,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,QLD,95,999,70.02,50.97,,,6343,4617,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
@@ -2296,7 +2296,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-10,QLD,25,29,16.62,10.84,,,61572,40159,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,QLD,20,24,14.31,8.95,,,48486,30325,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,QLD,16,19,6.38,3.42,,,16243,8707,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
-2021-08-10,QLD,0,999,40.74,22.51,1675486,925847,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
+2021-08-10,QLD,16,999,40.74,22.51,1675486,925847,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,QLD,50,999,65.58,33.8,1153465,594514,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,QLD,70,999,80.71,49.89,466313,288225,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,ACT,95,999,93.88,68.13,,,598,434,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
@@ -2316,7 +2316,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-10,ACT,25,29,21.93,12.63,,,7454,4293,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,ACT,20,24,15,8.25,,,4894,2692,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,ACT,16,19,6.63,3.13,,,1278,603,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
-2021-08-10,ACT,0,999,52.1,27.47,179252,94513,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
+2021-08-10,ACT,16,999,52.1,27.47,179252,94513,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,ACT,50,999,83.8,39.52,107101,50507,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,ACT,70,999,94.1,61,37591,24368,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,SA,95,999,74.8,53.54,,,3722,2664,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
@@ -2336,7 +2336,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-10,SA,25,29,17.83,11.73,,,20994,13811,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,SA,20,24,14.53,9.07,,,16626,10378,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,SA,16,19,7.2,3.88,,,5902,3180,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
-2021-08-10,SA,0,999,44.67,23.39,643415,336885,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
+2021-08-10,SA,16,999,44.67,23.39,643415,336885,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,SA,50,999,66.84,30.73,450741,207227,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,SA,70,999,79.56,44.39,191358,106753,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,NT,95,999,49.48,35.05,,,48,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
@@ -2356,7 +2356,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-10,NT,25,29,33.81,22.12,,,7449,4873,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,NT,20,24,28.08,16.7,,,4519,2688,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,NT,16,19,22.48,12.48,,,2721,1510,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
-2021-08-10,NT,0,999,45.56,28.21,86838,53767,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
+2021-08-10,NT,16,999,45.56,28.21,86838,53767,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,NT,50,999,61.98,34.64,38601,21575,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,NT,70,999,72.84,48.29,8991,5961,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,WA,95,999,71.43,52.35,,,3276,2401,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
@@ -2376,7 +2376,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-10,WA,25,29,11.94,7.87,,,22073,14549,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,WA,20,24,9.84,6.07,,,16404,10119,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,WA,16,19,2.88,1.28,,,3559,1582,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
-2021-08-10,WA,0,999,40.37,20.69,853792,437632,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
+2021-08-10,WA,16,999,40.37,20.69,853792,437632,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,WA,50,999,65.45,31.94,579446,282827,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,WA,70,999,78.52,47.11,220085,132036,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,TAS,95,999,72.35,53.32,,,840,619,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
@@ -2396,7 +2396,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-10,TAS,25,29,28.41,18.44,,,9692,6291,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,TAS,20,24,19.59,12.74,,,6198,4031,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,TAS,16,19,7.54,4.3,,,1863,1063,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
-2021-08-10,TAS,0,999,51.74,29.37,227765,129269,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
+2021-08-10,TAS,16,999,51.74,29.37,227765,129269,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,TAS,50,999,73,38.72,160620,85191,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-10,TAS,70,999,84.52,54.92,65208,42371,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-11-august-2021.pdf
 2021-08-11,NSW,95,999,76.41,55.29,,,13949,10093,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
@@ -2416,7 +2416,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-11,NSW,25,29,24.82,11.88,,,150879,72217,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,NSW,20,24,21.76,9.43,,,117555,50944,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,NSW,16,19,13.03,3.88,,,48917,14566,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
-2021-08-11,NSW,0,999,49.01,25.06,3218397,1645077,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
+2021-08-11,NSW,16,999,49.01,25.06,3218397,1645077,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,NSW,50,999,71.6,36.9,2010312,1036015,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,NSW,70,999,83.08,50.66,799706,487699,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,VIC,95,999,73.02,52.47,,,10318,7415,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
@@ -2436,7 +2436,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-11,VIC,25,29,17.36,10.04,,,92910,53733,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,VIC,20,24,13.62,7.52,,,64225,35461,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,VIC,16,19,4.86,2.09,,,14772,6353,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
-2021-08-11,VIC,0,999,45.85,24.2,2479545,1308532,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
+2021-08-11,VIC,16,999,45.85,24.2,2479545,1308532,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,VIC,50,999,72.31,33.14,1598829,732717,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,VIC,70,999,80.93,47.73,601749,354879,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,QLD,95,999,70.26,51.29,,,6365,4646,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
@@ -2456,7 +2456,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-11,QLD,25,29,16.97,11.02,,,62868,40826,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,QLD,20,24,14.63,9.14,,,49570,30969,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,QLD,16,19,6.55,3.51,,,16676,8936,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
-2021-08-11,QLD,0,999,41.26,23.07,1697002,948910,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
+2021-08-11,QLD,16,999,41.26,23.07,1697002,948910,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,QLD,50,999,66.16,34.75,1163669,611118,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,QLD,70,999,81.09,50.83,468499,293683,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,ACT,95,999,94.35,70.33,,,601,448,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
@@ -2476,7 +2476,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-11,ACT,25,29,22.37,12.76,,,7604,4337,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,ACT,20,24,15.36,8.36,,,5011,2728,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,ACT,16,19,6.84,3.26,,,1318,628,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
-2021-08-11,ACT,0,999,52.55,28.2,180795,97035,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
+2021-08-11,ACT,16,999,52.55,28.2,180795,97035,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,ACT,50,999,84.2,40.89,107612,52255,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,ACT,70,999,94.32,62.05,37677,24788,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,SA,95,999,75.06,53.82,,,3735,2678,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
@@ -2496,7 +2496,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-11,SA,25,29,18.18,11.87,,,21406,13976,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,SA,20,24,14.82,9.26,,,16958,10596,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,SA,16,19,7.4,3.99,,,6066,3271,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
-2021-08-11,SA,0,999,45.1,24.01,649580,345814,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
+2021-08-11,SA,16,999,45.1,24.01,649580,345814,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,SA,50,999,67.3,31.73,453870,213999,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,SA,70,999,79.88,45.34,192126,109038,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,NT,95,999,49.48,35.05,,,48,34,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
@@ -2516,7 +2516,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-11,NT,25,29,34.46,22.47,,,7592,4950,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,NT,20,24,28.72,17.02,,,4622,2739,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,NT,16,19,22.99,12.85,,,2782,1555,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
-2021-08-11,NT,0,999,46.17,28.83,88006,54936,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
+2021-08-11,NT,16,999,46.17,28.83,88006,54936,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,NT,50,999,62.47,35.56,38905,22146,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,NT,70,999,73.09,49.15,9021,6066,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,WA,95,999,71.76,52.79,,,3291,2421,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
@@ -2536,7 +2536,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-11,WA,25,29,12.14,7.98,,,22442,14752,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,WA,20,24,10.02,6.16,,,16704,10269,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,WA,16,19,2.97,1.33,,,3670,1644,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
-2021-08-11,WA,0,999,40.79,21.3,862697,450571,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
+2021-08-11,WA,16,999,40.79,21.3,862697,450571,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,WA,50,999,65.84,32.91,582933,291358,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,WA,70,999,78.79,47.93,220841,134352,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,TAS,95,999,72.52,53.57,,,842,622,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
@@ -2556,7 +2556,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-11,TAS,25,29,28.86,18.9,,,9846,6448,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,TAS,20,24,19.89,13.06,,,6293,4132,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,TAS,16,19,7.69,4.39,,,1900,1085,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
-2021-08-11,TAS,0,999,52.09,30.06,229308,132309,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
+2021-08-11,TAS,16,999,52.09,30.06,229308,132309,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,TAS,50,999,73.3,39.71,161297,87382,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-11,TAS,70,999,84.71,55.7,65360,42976,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-12-august-2021.pdf
 2021-08-12,NSW,95,999,76.82,55.85,,,14023,10195,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
@@ -2576,7 +2576,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-12,NSW,25,29,25.79,12.17,,,156775,73980,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,NSW,20,24,22.72,9.71,,,122741,52457,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,NSW,16,19,14.17,4.01,,,53197,15054,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
-2021-08-12,NSW,0,999,49.95,25.79,3280156,1693577,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
+2021-08-12,NSW,16,999,49.95,25.79,3280156,1693577,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,NSW,50,999,72.35,38.04,2031518,1068013,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,NSW,70,999,83.59,51.65,804605,497138,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,VIC,95,999,73.2,52.91,,,10344,7477,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
@@ -2596,7 +2596,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-12,VIC,25,29,18,10.17,,,96335,54429,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,VIC,20,24,14.16,7.64,,,66771,36026,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,VIC,16,19,5.16,2.14,,,15684,6505,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
-2021-08-12,VIC,0,999,46.37,24.79,2507925,1340713,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
+2021-08-12,VIC,16,999,46.37,24.79,2507925,1340713,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,VIC,50,999,72.69,34.24,1607337,757090,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,VIC,70,999,81.19,48.66,603699,361819,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,QLD,95,999,70.59,51.76,,,6395,4689,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
@@ -2616,7 +2616,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-12,QLD,25,29,17.41,11.18,,,64498,41418,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,QLD,20,24,15.04,9.3,,,50959,31511,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,QLD,16,19,6.81,3.6,,,17338,9165,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
-2021-08-12,QLD,0,999,41.86,23.66,1721652,972990,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
+2021-08-12,QLD,16,999,41.86,23.66,1721652,972990,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,QLD,50,999,66.79,35.79,1174663,629471,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,QLD,70,999,81.49,51.89,470828,299805,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,ACT,95,999,94.66,70.96,,,603,452,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
@@ -2636,7 +2636,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-12,ACT,25,29,22.81,12.83,,,7754,4361,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,ACT,20,24,15.78,8.44,,,5148,2754,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,ACT,16,19,6.99,3.28,,,1347,632,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
-2021-08-12,ACT,0,999,52.81,28.61,181701,98445,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
+2021-08-12,ACT,16,999,52.81,28.61,181701,98445,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,ACT,50,999,84.42,41.79,107890,53407,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,ACT,70,999,94.56,63.04,37773,25180,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,SA,95,999,75.22,54.28,,,3743,2701,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
@@ -2656,7 +2656,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-12,SA,25,29,18.54,12.09,,,21830,14235,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,SA,20,24,15.15,9.5,,,17335,10870,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,SA,16,19,7.59,4.13,,,6221,3385,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
-2021-08-12,SA,0,999,45.52,24.69,655701,355629,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
+2021-08-12,SA,16,999,45.52,24.69,655701,355629,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,SA,50,999,67.74,32.79,456806,221122,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,SA,70,999,80.17,46.32,192818,111404,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,NT,95,999,49.48,36.08,,,48,35,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
@@ -2676,7 +2676,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-12,NT,25,29,35.08,22.8,,,7728,5023,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,NT,20,24,29.36,17.36,,,4725,2794,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,NT,16,19,23.7,13.21,,,2868,1599,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
-2021-08-12,NT,0,999,46.82,29.46,89241,56139,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
+2021-08-12,NT,16,999,46.82,29.46,89241,56139,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,NT,50,999,62.98,36.51,39221,22741,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,NT,70,999,73.31,49.86,9049,6154,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,WA,95,999,72,53.34,,,3302,2446,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
@@ -2696,7 +2696,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-12,WA,25,29,12.33,8.08,,,22794,14937,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,WA,20,24,10.21,6.25,,,17021,10419,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,WA,16,19,3.06,1.36,,,3781,1681,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
-2021-08-12,WA,0,999,41.21,21.92,871653,463617,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
+2021-08-12,WA,16,999,41.21,21.92,871653,463617,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,WA,50,999,66.24,33.96,586437,300702,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,WA,70,999,79.06,48.99,221596,137300,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,TAS,95,999,72.7,54.01,,,844,627,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
@@ -2716,7 +2716,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-12,TAS,25,29,29.34,19.43,,,10009,6629,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,TAS,20,24,20.29,13.45,,,6420,4256,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,TAS,16,19,7.86,4.52,,,1942,1117,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
-2021-08-12,TAS,0,999,52.54,30.98,231265,136373,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
+2021-08-12,TAS,16,999,52.54,30.98,231265,136373,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,TAS,50,999,73.63,40.97,162018,90146,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-12,TAS,70,999,84.91,56.55,65516,43628,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-13-august-2021.pdf
 2021-08-13,NSW,95,999,77.26,56.4,,,14104,10296,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
@@ -2736,7 +2736,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-13,NSW,25,29,26.9,12.49,,,163523,75926,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,NSW,20,24,23.79,9.99,,,128521,53969,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,NSW,16,19,15.25,4.14,,,57251,15542,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
-2021-08-13,NSW,0,999,50.95,26.54,3345335,1742669,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
+2021-08-13,NSW,16,999,50.95,26.54,3345335,1742669,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,NSW,50,999,73.09,39.1,2052131,1097982,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,NSW,70,999,84.04,52.48,809013,505212,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,VIC,95,999,73.46,53.4,,,10381,7546,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
@@ -2756,7 +2756,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-13,VIC,25,29,18.69,10.35,,,100028,55392,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,VIC,20,24,14.79,7.8,,,69742,36781,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,VIC,16,19,5.5,2.22,,,16718,6748,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
-2021-08-13,VIC,0,999,46.94,25.43,2538663,1375135,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
+2021-08-13,VIC,16,999,46.94,25.43,2538663,1375135,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,VIC,50,999,73.09,35.34,1616117,781535,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,VIC,70,999,81.45,49.49,605582,367936,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,QLD,95,999,71.08,52.27,,,6439,4735,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
@@ -2776,7 +2776,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-13,QLD,25,29,17.82,11.37,,,66017,42122,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,QLD,20,24,15.39,9.5,,,52145,32188,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,QLD,16,19,7.05,3.7,,,17949,9420,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
-2021-08-13,QLD,0,999,42.41,24.23,1744341,996536,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
+2021-08-13,QLD,16,999,42.41,24.23,1744341,996536,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,QLD,50,999,67.33,36.74,1184168,646129,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,QLD,70,999,81.82,52.68,472715,304395,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,ACT,95,999,94.98,71.59,,,605,456,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
@@ -2796,7 +2796,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-13,ACT,25,29,23.89,13.23,,,8121,4497,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,ACT,20,24,16.62,8.74,,,5422,2852,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,ACT,16,19,7.47,3.5,,,1440,674,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
-2021-08-13,ACT,0,999,53.86,29.94,185330,103014,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
+2021-08-13,ACT,16,999,53.86,29.94,185330,103014,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,ACT,50,999,85.3,43.95,109013,56168,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,ACT,70,999,94.9,64.19,37910,25641,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,SA,95,999,75.5,54.7,,,3757,2722,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
@@ -2816,7 +2816,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-13,SA,25,29,18.93,12.31,,,22289,14494,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,SA,20,24,15.5,9.69,,,17736,11088,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,SA,16,19,7.77,4.26,,,6369,3492,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
-2021-08-13,SA,0,999,45.95,25.28,661822,364126,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
+2021-08-13,SA,16,999,45.95,25.28,661822,364126,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,SA,50,999,68.16,33.68,459663,227122,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,SA,70,999,80.45,47.13,193497,113361,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,NT,95,999,49.48,36.08,,,48,35,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
@@ -2836,7 +2836,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-13,NT,25,29,35.56,22.99,,,7834,5065,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,NT,20,24,29.91,17.66,,,4814,2842,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,NT,16,19,24.18,13.53,,,2927,1638,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
-2021-08-13,NT,0,999,47.4,29.99,90354,57145,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
+2021-08-13,NT,16,999,47.4,29.99,90354,57145,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,NT,50,999,63.54,37.47,39575,23336,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,NT,70,999,73.67,50.55,9093,6239,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,WA,95,999,72.44,53.6,,,3322,2458,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
@@ -2856,7 +2856,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-13,WA,25,29,12.59,8.2,,,23274,15159,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,WA,20,24,10.42,6.36,,,17371,10603,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,WA,16,19,3.15,1.41,,,3893,1742,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
-2021-08-13,WA,0,999,41.62,22.51,880259,476011,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
+2021-08-13,WA,16,999,41.62,22.51,880259,476011,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,WA,50,999,66.62,34.93,589837,309295,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,WA,70,999,79.34,49.82,222380,139634,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,TAS,95,999,73.13,54.09,,,849,628,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
@@ -2876,7 +2876,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-13,TAS,25,29,29.71,19.95,,,10136,6806,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,TAS,20,24,20.6,13.8,,,6518,4366,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,TAS,16,19,8.04,4.71,,,1987,1164,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
-2021-08-13,TAS,0,999,52.91,31.65,232915,139298,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
+2021-08-13,TAS,16,999,52.91,31.65,232915,139298,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,TAS,50,999,73.95,41.73,162710,91821,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-13,TAS,70,999,85.15,57.22,65697,44148,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-14-august-2021.pdf
 2021-08-14,NSW,95,999,77.51,56.63,,,14149,10338,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
@@ -2896,7 +2896,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-14,NSW,25,29,27.66,12.69,,,168143,77141,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,NSW,20,24,24.55,10.17,,,132627,54942,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,NSW,16,19,16.02,4.24,,,60142,15918,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
-2021-08-14,NSW,0,999,51.55,26.92,3385107,1767176,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
+2021-08-14,NSW,16,999,51.55,26.92,3385107,1767176,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,NSW,50,999,73.48,39.6,2063168,1111948,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,NSW,70,999,84.26,52.85,811127,508693,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,VIC,95,999,73.63,53.61,,,10405,7576,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
@@ -2916,7 +2916,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-14,VIC,25,29,19.17,10.5,,,102596,56195,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,VIC,20,24,15.19,7.93,,,71628,37394,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,VIC,16,19,5.75,2.29,,,17478,6961,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
-2021-08-14,VIC,0,999,47.3,25.84,2558270,1397397,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
+2021-08-14,VIC,16,999,47.3,25.84,2558270,1397397,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,VIC,50,999,73.32,36,1621214,796057,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,VIC,70,999,81.56,49.91,606439,371067,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,QLD,95,999,71.22,52.51,,,6452,4757,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
@@ -2936,7 +2936,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-14,QLD,25,29,18.11,11.52,,,67092,42678,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,QLD,20,24,15.66,9.65,,,53060,32697,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,QLD,16,19,7.23,3.78,,,18407,9623,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
-2021-08-14,QLD,0,999,42.77,24.56,1759181,1010014,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
+2021-08-14,QLD,16,999,42.77,24.56,1759181,1010014,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,QLD,50,999,67.63,37.2,1189470,654228,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,QLD,70,999,81.97,53.05,473597,306483,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,ACT,95,999,94.98,71.9,,,605,458,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
@@ -2956,7 +2956,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-14,ACT,25,29,24.3,13.31,,,8260,4524,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,ACT,20,24,16.99,8.79,,,5543,2868,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,ACT,16,19,7.64,3.54,,,1472,682,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
-2021-08-14,ACT,0,999,54.06,30.31,186020,104279,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
+2021-08-14,ACT,16,999,54.06,30.31,186020,104279,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,ACT,50,999,85.43,44.75,109177,57192,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,ACT,70,999,95.05,64.88,37967,25918,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,SA,95,999,75.68,54.84,,,3766,2729,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
@@ -2976,7 +2976,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-14,SA,25,29,19.15,12.47,,,22548,14683,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,SA,20,24,15.67,9.85,,,17930,11271,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,SA,16,19,7.92,4.36,,,6492,3574,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
-2021-08-14,SA,0,999,46.2,25.59,665487,368567,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
+2021-08-14,SA,16,999,46.2,25.59,665487,368567,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,SA,50,999,68.39,34.04,461181,229552,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,SA,70,999,80.56,47.39,193762,113972,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,NT,95,999,49.48,36.08,,,48,35,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
@@ -2996,7 +2996,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-14,NT,25,29,35.76,23.12,,,7878,5094,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,NT,20,24,30.1,17.75,,,4844,2857,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,NT,16,19,24.37,13.65,,,2950,1652,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
-2021-08-14,NT,0,999,47.63,30.28,90793,57697,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
+2021-08-14,NT,16,999,47.63,30.28,90793,57697,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,NT,50,999,63.74,38,39699,23665,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,NT,70,999,73.77,50.76,9105,6265,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,WA,95,999,72.57,53.97,,,3328,2475,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
@@ -3016,7 +3016,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-14,WA,25,29,12.75,8.27,,,23570,15288,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,WA,20,24,10.55,6.42,,,17588,10703,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,WA,16,19,3.19,1.43,,,3942,1767,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
-2021-08-14,WA,0,999,41.94,22.86,886964,483431,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
+2021-08-14,WA,16,999,41.94,22.86,886964,483431,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,WA,50,999,66.83,35.5,591679,314274,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,WA,70,999,79.45,50.28,222689,140928,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,TAS,95,999,73.73,54.35,,,856,631,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
@@ -3036,7 +3036,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-14,TAS,25,29,29.93,20.38,,,10211,6953,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,TAS,20,24,20.74,14.04,,,6562,4442,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,TAS,16,19,8.1,4.82,,,2002,1191,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
-2021-08-14,TAS,0,999,53.16,32.27,233998,142028,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
+2021-08-14,TAS,16,999,53.16,32.27,233998,142028,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,TAS,50,999,74.17,42.5,163202,93508,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-14,TAS,70,999,85.27,57.77,65789,44574,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-15-august-2021.pdf
 2021-08-15,NSW,95,999,77.65,56.75,,,14175,10360,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
@@ -3056,7 +3056,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-15,NSW,25,29,28.44,12.85,,,172884,78114,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,NSW,20,24,25.28,10.32,,,136571,55752,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,NSW,16,19,16.77,4.34,,,62958,16293,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
-2021-08-15,NSW,0,999,52.05,27.13,3417891,1781578,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
+2021-08-15,NSW,16,999,52.05,27.13,3417891,1781578,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,NSW,50,999,73.74,39.85,2070363,1118814,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,NSW,70,999,84.39,53.01,812386,510248,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,VIC,95,999,73.73,53.7,,,10419,7588,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
@@ -3076,7 +3076,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-15,VIC,25,29,19.3,10.53,,,103292,56356,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,VIC,20,24,15.29,7.96,,,72100,37535,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,VIC,16,19,5.8,2.3,,,17630,6991,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
-2021-08-15,VIC,0,999,47.39,25.94,2563162,1402833,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
+2021-08-15,VIC,16,999,47.39,25.94,2563162,1402833,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,VIC,50,999,73.38,36.16,1622697,799675,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,VIC,70,999,81.61,50.02,606777,371902,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,QLD,95,999,71.34,52.57,,,6463,4762,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
@@ -3096,7 +3096,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-15,QLD,25,29,18.31,11.6,,,67833,42974,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,QLD,20,24,15.83,9.76,,,53636,33069,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,QLD,16,19,7.43,3.86,,,18916,9827,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
-2021-08-15,QLD,0,999,43.02,24.71,1769610,1016058,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
+2021-08-15,QLD,16,999,43.02,24.71,1769610,1016058,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,QLD,50,999,67.8,37.35,1192518,656876,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,QLD,70,999,82.01,53.13,473852,306972,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,ACT,95,999,95.13,72.06,,,606,459,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
@@ -3116,7 +3116,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-15,ACT,25,29,24.58,13.34,,,8355,4535,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,ACT,20,24,17.2,8.81,,,5612,2874,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,ACT,16,19,7.81,3.55,,,1505,684,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
-2021-08-15,ACT,0,999,54.17,30.47,186398,104819,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
+2021-08-15,ACT,16,999,54.17,30.47,186398,104819,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,ACT,50,999,85.51,45.1,109278,57641,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,ACT,70,999,95.13,65.15,38002,26023,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,SA,95,999,75.72,54.84,,,3768,2729,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
@@ -3136,7 +3136,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-15,SA,25,29,19.32,12.6,,,22748,14836,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,SA,20,24,15.82,9.99,,,18102,11431,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,SA,16,19,8.03,4.48,,,6582,3672,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
-2021-08-15,SA,0,999,46.37,25.76,667989,371099,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
+2021-08-15,SA,16,999,46.37,25.76,667989,371099,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,SA,50,999,68.51,34.21,462047,230689,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,SA,70,999,80.6,47.46,193844,114146,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,NT,95,999,49.48,36.08,,,48,35,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
@@ -3156,7 +3156,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-15,NT,25,29,35.91,23.17,,,7911,5105,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,NT,20,24,30.2,17.8,,,4860,2865,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,NT,16,19,24.48,13.72,,,2963,1661,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
-2021-08-15,NT,0,999,47.75,30.38,91020,57890,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
+2021-08-15,NT,16,999,47.75,30.38,91020,57890,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,NT,50,999,63.79,38.09,39727,23722,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,NT,70,999,73.8,50.79,9109,6269,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,WA,95,999,72.68,54.03,,,3333,2478,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
@@ -3176,7 +3176,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-15,WA,25,29,12.85,8.38,,,23755,15492,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,WA,20,24,10.68,6.51,,,17805,10853,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,WA,16,19,3.24,1.47,,,4004,1817,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
-2021-08-15,WA,0,999,42.16,23.16,891740,489732,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
+2021-08-15,WA,16,999,42.16,23.16,891740,489732,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,WA,50,999,66.95,35.77,592751,316681,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,WA,70,999,79.51,50.36,222842,141145,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,TAS,95,999,73.82,54.52,,,857,633,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
@@ -3196,7 +3196,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-15,TAS,25,29,30.25,20.6,,,10320,7028,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,TAS,20,24,20.92,14.2,,,6619,4493,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,TAS,16,19,8.25,4.9,,,2039,1211,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
-2021-08-15,TAS,0,999,53.38,32.53,234964,143169,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
+2021-08-15,TAS,16,999,53.38,32.53,234964,143169,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,TAS,50,999,74.28,42.79,163445,94162,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-15,TAS,70,999,85.31,57.99,65823,44740,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-16-august-2021.pdf
 2021-08-16,NSW,95,999,78.01,57.17,,,14241,10436,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
@@ -3216,7 +3216,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-16,NSW,25,29,29.63,13.13,,,180118,79816,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,NSW,20,24,26.53,10.56,,,143324,57049,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,NSW,16,19,17.49,4.46,,,65661,16744,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
-2021-08-16,NSW,0,999,53.01,27.81,3480823,1826165,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
+2021-08-16,NSW,16,999,53.01,27.81,3480823,1826165,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,NSW,50,999,74.42,40.88,2089546,1147837,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,NSW,70,999,84.83,53.86,816575,518498,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,VIC,95,999,73.91,54.01,,,10444,7632,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
@@ -3236,7 +3236,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-16,VIC,25,29,20.16,10.74,,,107895,57480,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,VIC,20,24,16.13,8.16,,,76061,38478,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,VIC,16,19,6.3,2.39,,,19149,7265,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
-2021-08-16,VIC,0,999,48.11,26.68,2601959,1442497,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
+2021-08-16,VIC,16,999,48.11,26.68,2601959,1442497,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,VIC,50,999,73.85,37.4,1632921,827029,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,VIC,70,999,81.86,50.82,608636,377833,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,QLD,95,999,71.6,52.89,,,6486,4791,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
@@ -3256,7 +3256,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-16,QLD,25,29,18.69,11.72,,,69240,43419,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,QLD,20,24,16.21,9.89,,,54923,33510,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,QLD,16,19,7.76,3.92,,,19756,9980,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
-2021-08-16,QLD,0,999,43.49,25.18,1789060,1035432,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
+2021-08-16,QLD,16,999,43.49,25.18,1789060,1035432,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,QLD,50,999,68.24,38.18,1200197,671470,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,QLD,70,999,82.28,53.89,475383,311330,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,ACT,95,999,95.29,72.53,,,607,462,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
@@ -3276,7 +3276,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-16,ACT,25,29,25.48,13.6,,,8661,4623,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,ACT,20,24,18.11,9.04,,,5909,2949,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,ACT,16,19,8.18,3.64,,,1576,701,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
-2021-08-16,ACT,0,999,54.78,31.27,188473,107593,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
+2021-08-16,ACT,16,999,54.78,31.27,188473,107593,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,ACT,50,999,85.96,46.4,109864,59299,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,ACT,70,999,95.45,65.92,38128,26334,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,SA,95,999,75.96,55.08,,,3780,2741,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
@@ -3296,7 +3296,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-16,SA,25,29,19.71,12.84,,,23208,15118,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,SA,20,24,16.17,10.2,,,18503,11671,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,SA,16,19,8.22,4.63,,,6738,3795,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
-2021-08-16,SA,0,999,46.78,26.35,673854,379539,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
+2021-08-16,SA,16,999,46.78,26.35,673854,379539,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,SA,50,999,68.9,35.1,464679,236718,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,SA,70,999,80.86,48.21,194478,115948,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,NT,95,999,50.52,36.08,,,49,35,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
@@ -3316,7 +3316,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-16,NT,25,29,36.49,23.38,,,8039,5151,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,NT,20,24,30.74,18.01,,,4947,2899,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,NT,16,19,24.98,13.86,,,3023,1677,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
-2021-08-16,NT,0,999,48.28,30.73,92034,58556,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
+2021-08-16,NT,16,999,48.28,30.73,92034,58556,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,NT,50,999,64.2,38.67,39984,24083,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,NT,70,999,74,51.24,9134,6324,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,WA,95,999,72.87,54.54,,,3342,2501,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
@@ -3336,7 +3336,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-16,WA,25,29,13.2,8.5,,,24402,15713,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,WA,20,24,10.96,6.66,,,18271,11103,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,WA,16,19,3.4,1.53,,,4201,1891,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
-2021-08-16,WA,0,999,42.71,23.81,903289,503484,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
+2021-08-16,WA,16,999,42.71,23.81,903289,503484,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,WA,50,999,67.39,36.87,596635,326401,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,WA,70,999,79.77,51.26,223569,143683,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,TAS,95,999,73.82,54.61,,,857,634,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
@@ -3356,7 +3356,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-16,TAS,25,29,30.72,20.96,,,10480,7151,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,TAS,20,24,21.34,14.49,,,6752,4585,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,TAS,16,19,8.44,5.01,,,2086,1238,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
-2021-08-16,TAS,0,999,53.79,33.09,236769,145662,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
+2021-08-16,TAS,16,999,53.79,33.09,236769,145662,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,TAS,50,999,74.61,43.58,164169,95893,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-16,TAS,70,999,85.54,58.61,65999,45223,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-17-august-2021.pdf
 2021-08-17,NSW,95,999,78.39,57.64,,,14310,10522,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
@@ -3376,7 +3376,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-17,NSW,25,29,30.94,13.4,,,188081,81457,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,NSW,20,24,27.85,10.8,,,150455,58345,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,NSW,16,19,18.31,4.6,,,68739,17269,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
-2021-08-17,NSW,0,999,54.02,28.5,3547120,1871458,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
+2021-08-17,NSW,16,999,54.02,28.5,3547120,1871458,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,NSW,50,999,75.12,41.96,2109220,1178061,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,NSW,70,999,85.3,54.79,821079,527422,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,VIC,95,999,74.15,54.5,,,10478,7701,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
@@ -3396,7 +3396,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-17,VIC,25,29,20.82,10.9,,,111427,58336,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,VIC,20,24,16.79,8.28,,,79173,39044,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,VIC,16,19,6.67,2.45,,,20274,7447,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
-2021-08-17,VIC,0,999,48.67,27.28,2632389,1475180,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
+2021-08-17,VIC,16,999,48.67,27.28,2632389,1475180,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,VIC,50,999,74.26,38.53,1642008,851958,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,VIC,70,999,82.15,51.72,610800,384566,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,QLD,95,999,71.92,53.43,,,6515,4840,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
@@ -3416,7 +3416,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-17,QLD,25,29,19.15,11.86,,,70945,43938,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,QLD,20,24,16.62,10.03,,,56313,33984,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,QLD,16,19,8.02,4,,,20418,10184,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
-2021-08-17,QLD,0,999,44.05,25.71,1811893,1057330,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
+2021-08-17,QLD,16,999,44.05,25.71,1811893,1057330,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,QLD,50,999,68.79,39.12,1209842,688130,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,QLD,70,999,82.63,54.78,477431,316478,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,ACT,95,999,95.29,73,,,607,465,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
@@ -3436,7 +3436,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-17,ACT,25,29,26.91,13.79,,,9147,4687,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,ACT,20,24,19.31,9.19,,,6300,2998,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,ACT,16,19,8.88,3.74,,,1711,721,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
-2021-08-17,ACT,0,999,55.9,32.18,192325,110697,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
+2021-08-17,ACT,16,999,55.9,32.18,192325,110697,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,ACT,50,999,86.8,47.91,110930,61234,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,ACT,70,999,95.79,66.74,38264,26661,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,SA,95,999,76.15,55.49,,,3789,2761,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
@@ -3456,7 +3456,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-17,SA,25,29,20.11,13.05,,,23679,15366,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,SA,20,24,16.55,10.41,,,18937,11912,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,SA,16,19,8.45,4.78,,,6926,3918,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
-2021-08-17,SA,0,999,47.25,26.97,680678,388472,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
+2021-08-17,SA,16,999,47.25,26.97,680678,388472,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,SA,50,999,69.36,36.03,467753,242955,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,SA,70,999,81.14,48.95,195157,117743,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,NT,95,999,51.55,36.08,,,50,35,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
@@ -3476,7 +3476,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-17,NT,25,29,37.17,23.68,,,8189,5217,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,NT,20,24,31.51,18.29,,,5071,2944,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,NT,16,19,25.77,14.13,,,3119,1710,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
-2021-08-17,NT,0,999,48.94,31.17,93291,59404,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
+2021-08-17,NT,16,999,48.94,31.17,93291,59404,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,NT,50,999,64.66,39.39,40270,24530,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,NT,70,999,74.28,51.65,9168,6375,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,WA,95,999,73.07,54.86,,,3351,2516,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
@@ -3496,7 +3496,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-17,WA,25,29,13.63,8.62,,,25197,15935,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,WA,20,24,11.36,6.77,,,18938,11286,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,WA,16,19,3.62,1.57,,,4473,1940,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
-2021-08-17,WA,0,999,43.22,27.28,914091,1475180,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
+2021-08-17,WA,16,999,43.22,27.28,914091,1475180,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,WA,50,999,67.75,38.53,599863,851958,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,WA,70,999,79.97,51.72,224151,384566,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,TAS,95,999,73.99,54.87,,,859,637,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
@@ -3516,7 +3516,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-17,TAS,25,29,31.29,21.3,,,10675,7266,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,TAS,20,24,21.71,14.69,,,6869,4648,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,TAS,16,19,8.63,5.15,,,2133,1273,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
-2021-08-17,TAS,0,999,54.2,33.79,238592,148716,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
+2021-08-17,TAS,16,999,54.2,33.79,238592,148716,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,TAS,50,999,74.97,44.61,164950,98149,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-17,TAS,70,999,85.79,59.49,66190,45899,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-18-august-2021.pdf
 2021-08-18,NSW,95,999,78.79,58.28,,,14383,10639,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
@@ -3536,7 +3536,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-18,NSW,25,29,32.52,13.77,,,197686,83707,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,NSW,20,24,29.44,11.14,,,159045,60182,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,NSW,16,19,19.37,4.78,,,72719,17945,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
-2021-08-18,NSW,0,999,55.23,29.32,3625997,1924839,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
+2021-08-18,NSW,16,999,55.23,29.32,3625997,1924839,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,NSW,50,999,75.91,43.12,2131524,1210778,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,NSW,70,999,85.8,55.74,825963,536533,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,VIC,95,999,74.43,54.99,,,10518,7771,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
@@ -3556,7 +3556,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-18,VIC,25,29,21.49,11.07,,,115013,59246,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,VIC,20,24,17.46,8.44,,,82333,39799,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,VIC,16,19,7.11,2.53,,,21611,7690,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
-2021-08-18,VIC,0,999,49.25,27.96,2663345,1512114,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
+2021-08-18,VIC,16,999,49.25,27.96,2663345,1512114,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,VIC,50,999,74.68,39.79,1651309,879914,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,VIC,70,999,82.45,52.74,612997,392121,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,QLD,95,999,72.26,53.9,,,6546,4883,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
@@ -3576,7 +3576,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-18,QLD,25,29,19.69,12.06,,,72945,44678,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,QLD,20,24,17.15,10.22,,,58108,34628,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,QLD,16,19,8.38,4.1,,,21335,10438,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
-2021-08-18,QLD,0,999,44.66,26.3,1836767,1081599,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
+2021-08-18,QLD,16,999,44.66,26.3,1836767,1081599,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,QLD,50,999,69.34,40.11,1219577,705497,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,QLD,70,999,82.99,55.67,479472,321640,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,ACT,95,999,95.76,73.63,,,610,469,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
@@ -3596,7 +3596,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-18,ACT,25,29,28,13.91,,,9518,4728,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,ACT,20,24,20.09,9.28,,,6555,3028,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,ACT,16,19,9.4,3.79,,,1811,730,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
-2021-08-18,ACT,0,999,56.43,32.59,194124,112125,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
+2021-08-18,ACT,16,999,56.43,32.59,194124,112125,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,ACT,50,999,87.21,48.83,111455,62409,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,ACT,70,999,96.16,67.59,38414,26999,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,SA,95,999,76.39,55.83,,,3801,2778,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
@@ -3616,7 +3616,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-18,SA,25,29,20.66,13.26,,,24326,15613,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,SA,20,24,17,10.59,,,19452,12118,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,SA,16,19,8.76,4.9,,,7180,4016,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
-2021-08-18,SA,0,999,47.79,27.64,688316,398074,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
+2021-08-18,SA,16,999,47.79,27.64,688316,398074,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,SA,50,999,69.9,37.1,471381,250180,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,SA,70,999,81.53,49.94,196100,120108,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,NT,95,999,52.58,36.08,,,51,35,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
@@ -3636,7 +3636,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-18,NT,25,29,37.94,24.21,,,8359,5334,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,NT,20,24,32.28,18.75,,,5195,3018,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,NT,16,19,26.6,14.45,,,3219,1749,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
-2021-08-18,NT,0,999,49.7,31.89,94719,60776,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
+2021-08-18,NT,16,999,49.7,31.89,94719,60776,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,NT,50,999,65.22,40.36,40621,25139,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,NT,70,999,74.55,52.32,9202,6458,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,WA,95,999,73.29,55.34,,,3361,2538,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
@@ -3656,7 +3656,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-18,WA,25,29,14.56,8.78,,,26916,16231,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,WA,20,24,12.12,6.9,,,20205,11503,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,WA,16,19,4.03,1.62,,,4980,2002,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
-2021-08-18,WA,0,999,43.92,25.06,928831,530080,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
+2021-08-18,WA,16,999,43.92,25.06,928831,530080,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,WA,50,999,68.23,38.84,604087,343853,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,WA,70,999,80.26,52.94,224957,148382,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,TAS,95,999,74.16,55.3,,,861,642,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
@@ -3676,7 +3676,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-18,TAS,25,29,31.85,21.59,,,10866,7365,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,TAS,20,24,22.13,14.88,,,7002,4708,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,TAS,16,19,8.89,5.22,,,2197,1290,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
-2021-08-18,TAS,0,999,54.64,34.44,240512,151592,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
+2021-08-18,TAS,16,999,54.64,34.44,240512,151592,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,TAS,50,999,75.28,45.6,165638,100343,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-18,TAS,70,999,86.04,60.2,66388,46450,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-19-august-2021.pdf
 2021-08-19,NSW,95,999,79.18,58.76,,,14454,10727,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
@@ -3696,7 +3696,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-19,NSW,25,29,34.03,14.07,,,206865,85530,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,NSW,20,24,31,11.43,,,167472,61749,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,NSW,16,19,20.4,4.95,,,76585,18583,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
-2021-08-19,NSW,0,999,56.35,30.05,3699581,1973224,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
+2021-08-19,NSW,16,999,56.35,30.05,3699581,1973224,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,NSW,50,999,76.65,44.22,2152145,1241508,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,NSW,70,999,86.29,56.66,830638,545378,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,VIC,95,999,74.67,55.5,,,10552,7843,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
@@ -3716,7 +3716,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-19,VIC,25,29,22.22,11.23,,,118920,60102,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,VIC,20,24,18.18,8.58,,,85728,40459,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,VIC,16,19,7.53,2.6,,,22888,7903,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
-2021-08-19,VIC,0,999,49.85,28.65,2695760,1549472,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
+2021-08-19,VIC,16,999,49.85,28.65,2695760,1549472,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,VIC,50,999,75.11,41.09,1660743,908682,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,VIC,70,999,82.75,53.76,615273,399745,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,QLD,95,999,72.48,54.38,,,6566,4926,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
@@ -3736,7 +3736,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-19,QLD,25,29,20.25,12.24,,,75020,45345,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,QLD,20,24,17.68,10.39,,,59904,35204,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,QLD,16,19,8.78,4.2,,,22353,10693,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
-2021-08-19,QLD,0,999,45.24,26.84,1860669,1103840,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
+2021-08-19,QLD,16,999,45.24,26.84,1860669,1103840,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,QLD,50,999,69.87,41.03,1228825,721700,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,QLD,70,999,83.32,56.51,481388,326507,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,ACT,95,999,96.86,73.78,,,617,470,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
@@ -3756,7 +3756,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-19,ACT,25,29,29.68,14.44,,,10089,4908,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,ACT,20,24,21.51,9.66,,,7018,3152,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,ACT,16,19,10.19,4.02,,,1964,775,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
-2021-08-19,ACT,0,999,57.54,34.13,197963,117405,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
+2021-08-19,ACT,16,999,57.54,34.13,197963,117405,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,ACT,50,999,87.98,51.04,112436,65226,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,ACT,70,999,96.6,68.67,38588,27429,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,SA,95,999,76.63,56.17,,,3813,2795,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
@@ -3776,7 +3776,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-19,SA,25,29,21.18,13.48,,,24938,15872,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,SA,20,24,17.44,10.82,,,19956,12381,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,SA,16,19,9.07,5.03,,,7434,4123,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
-2021-08-19,SA,0,999,48.27,28.29,695320,407529,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
+2021-08-19,SA,16,999,48.27,28.29,695320,407529,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,SA,50,999,70.36,38.14,474468,257215,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,SA,70,999,81.86,50.9,196891,122425,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,NT,95,999,53.61,36.08,,,52,35,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
@@ -3796,7 +3796,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-19,NT,25,29,38.92,24.63,,,8574,5426,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,NT,20,24,33.19,19.17,,,5342,3085,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,NT,16,19,27.49,14.81,,,3327,1792,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
-2021-08-19,NT,0,999,50.48,32.58,96208,62079,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
+2021-08-19,NT,16,999,50.48,32.58,96208,62079,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,NT,50,999,65.82,41.3,40993,25721,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,NT,70,999,74.91,53.2,9246,6567,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,WA,95,999,73.53,55.97,,,3372,2567,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
@@ -3816,7 +3816,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-19,WA,25,29,15.37,8.91,,,28413,16471,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,WA,20,24,12.83,7,,,21389,11670,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,WA,16,19,4.43,1.66,,,5474,2051,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
-2021-08-19,WA,0,999,44.58,25.73,942781,544199,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
+2021-08-19,WA,16,999,44.58,25.73,942781,544199,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,WA,50,999,68.68,39.92,608090,353411,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,WA,70,999,80.55,53.89,225773,151055,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,TAS,95,999,74.25,55.64,,,862,646,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
@@ -3836,7 +3836,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-19,TAS,25,29,32.41,22.3,,,11057,7608,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,TAS,20,24,22.55,15.27,,,7135,4832,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,TAS,16,19,9.11,5.4,,,2251,1335,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
-2021-08-19,TAS,0,999,55.08,35.34,242440,155575,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
+2021-08-19,TAS,16,999,55.08,35.34,242440,155575,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,TAS,50,999,75.63,46.74,166406,102853,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-19,TAS,70,999,86.28,61.01,66568,47076,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-20-august-2021.pdf
 2021-08-20,NSW,95,999,79.62,59.2,,,14535,10807,18255,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
@@ -3856,7 +3856,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-20,NSW,25,29,35.73,14.42,,,217199,87658,607891,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,NSW,20,24,32.76,11.74,,,176980,63423,540233,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,NSW,16,19,21.74,5.15,,,81616,19334,375419,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
-2021-08-20,NSW,0,999,57.56,30.81,3779127,2022928,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
+2021-08-20,NSW,16,999,57.56,30.81,3779127,2022928,,,6565651,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,NSW,50,999,77.36,45.29,2172094,1271596,,,2807793,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,NSW,70,999,86.72,57.48,834780,553314,,,962606,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,VIC,95,999,75,56.01,,,10598,7915,14131,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
@@ -3876,7 +3876,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-20,VIC,25,29,22.91,11.42,,,122613,61119,535193,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,VIC,20,24,18.84,8.74,,,88840,41213,471550,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,VIC,16,19,7.94,2.67,,,24134,8116,303958,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
-2021-08-20,VIC,0,999,50.43,29.37,2726850,1588286,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
+2021-08-20,VIC,16,999,50.43,29.37,2726850,1588286,,,5407574,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,VIC,50,999,75.53,42.4,1670076,937541,,,2211211,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,VIC,70,999,83.04,54.65,617383,406320,,,743519,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,QLD,95,999,72.76,54.81,,,6591,4965,9059,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
@@ -3896,7 +3896,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-20,QLD,25,29,20.87,12.43,,,77317,46049,370468,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,QLD,20,24,18.27,10.57,,,61903,35814,338824,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,QLD,16,19,9.27,4.31,,,23600,10973,254589,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
-2021-08-20,QLD,0,999,45.88,27.4,1887055,1126894,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
+2021-08-20,QLD,16,999,45.88,27.4,1887055,1126894,,,4112707,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,QLD,50,999,70.4,41.95,1238258,737762,,,1758855,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,QLD,70,999,83.64,57.24,483243,330733,,,577767,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,ACT,95,999,95,75.51,,,605,481,637,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
@@ -3916,7 +3916,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-20,ACT,25,29,31.38,14.99,,,10667,5095,33992,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,ACT,20,24,22.84,10.09,,,7452,3292,32626,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,ACT,16,19,11.07,4.23,,,2133,815,19271,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
-2021-08-20,ACT,0,999,58.75,35.7,202117,122835,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
+2021-08-20,ACT,16,999,58.75,35.7,202117,122835,,,344037,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,ACT,50,999,88.84,53.47,113539,68333,,,127802,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,ACT,70,999,97.08,69.96,38781,27948,,,39946,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,SA,95,999,76.93,56.55,,,3828,2814,4976,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
@@ -3936,7 +3936,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-20,SA,25,29,21.7,13.68,,,25551,16108,117745,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,SA,20,24,17.86,11.02,,,20436,12610,114425,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,SA,16,19,9.32,5.13,,,7639,4205,81968,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
-2021-08-20,SA,0,999,48.78,28.96,702665,417196,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
+2021-08-20,SA,16,999,48.78,28.96,702665,417196,,,1440400,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,SA,50,999,70.84,39.2,477741,264358,,,674384,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,SA,70,999,82.14,51.8,197558,124586,,,240514,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,NT,95,999,53.61,36.08,,,52,35,97,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
@@ -3956,7 +3956,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-20,NT,25,29,39.56,24.99,,,8715,5506,22031,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,NT,20,24,33.98,19.57,,,5469,3150,16094,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,NT,16,19,28.35,15.16,,,3431,1835,12103,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
-2021-08-20,NT,0,999,51.16,33.24,97499,63337,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
+2021-08-20,NT,16,999,51.16,33.24,97499,63337,,,190571,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,NT,50,999,66.35,42.31,41325,26348,,,62280,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,NT,70,999,75.15,53.84,9276,6646,,,12343,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,WA,95,999,73.79,56.3,,,3384,2582,4586,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
@@ -3976,7 +3976,7 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-20,WA,25,29,15.86,9.05,,,29319,16730,184863,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,WA,20,24,13.26,7.12,,,22106,11870,166709,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,WA,16,19,4.76,1.72,,,5882,2125,123573,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
-2021-08-20,WA,0,999,45.13,26.36,954557,557506,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
+2021-08-20,WA,16,999,45.13,26.36,954557,557506,,,2114978,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,WA,50,999,69.1,40.91,611822,362226,,,885370,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,WA,70,999,80.77,54.63,226388,153122,,,280281,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,TAS,95,999,74.5,55.73,,,865,647,1161,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
@@ -3996,6 +3996,6 @@ DATE_AS_AT,STATE,AGE_LOWER,AGE_UPPER,AIR_RESIDENCE_FIRST_DOSE_PCT,AIR_RESIDENCE_
 2021-08-20,TAS,25,29,32.88,22.65,,,11217,7727,34115,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,TAS,20,24,22.91,15.52,,,7249,4911,31641,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,TAS,16,19,9.41,5.5,,,2325,1359,24713,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
-2021-08-20,TAS,0,999,55.51,35.98,244333,158359,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
+2021-08-20,TAS,16,999,55.51,35.98,244333,158359,,,440172,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,TAS,50,999,75.98,47.62,167184,104789,,,220036,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf
 2021-08-20,TAS,70,999,86.56,61.73,66784,47624,,,77155,Y,https://www.health.gov.au/sites/default/files/documents/2021/08/covid-19-vaccine-rollout-update-21-august-2021.pdf

--- a/docs/data/air_residence.json
+++ b/docs/data/air_residence.json
@@ -223,7 +223,7 @@
     {
         "DATE_AS_AT": "2021-07-27",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.04,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 17.21,
@@ -483,7 +483,7 @@
     {
         "DATE_AS_AT": "2021-07-27",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.89,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 17.64,
@@ -743,7 +743,7 @@
     {
         "DATE_AS_AT": "2021-07-27",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 35.86,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 16.8,
@@ -1003,7 +1003,7 @@
     {
         "DATE_AS_AT": "2021-07-27",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.53,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.4,
@@ -1263,7 +1263,7 @@
     {
         "DATE_AS_AT": "2021-07-27",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.84,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 17.63,
@@ -1523,7 +1523,7 @@
     {
         "DATE_AS_AT": "2021-07-27",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.52,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.91,
@@ -1783,7 +1783,7 @@
     {
         "DATE_AS_AT": "2021-07-27",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 35.88,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 14.4,
@@ -2043,7 +2043,7 @@
     {
         "DATE_AS_AT": "2021-07-27",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.06,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.79,
@@ -2303,7 +2303,7 @@
     {
         "DATE_AS_AT": "2021-07-28",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.49,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 17.61,
@@ -2563,7 +2563,7 @@
     {
         "DATE_AS_AT": "2021-07-28",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.02,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18,
@@ -2823,7 +2823,7 @@
     {
         "DATE_AS_AT": "2021-07-28",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 35.94,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 17.11,
@@ -3083,7 +3083,7 @@
     {
         "DATE_AS_AT": "2021-07-28",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.1,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.32,
@@ -3343,7 +3343,7 @@
     {
         "DATE_AS_AT": "2021-07-28",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.02,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 17.96,
@@ -3603,7 +3603,7 @@
     {
         "DATE_AS_AT": "2021-07-28",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.57,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.99,
@@ -3863,7 +3863,7 @@
     {
         "DATE_AS_AT": "2021-07-28",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 36.06,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 14.86,
@@ -4123,7 +4123,7 @@
     {
         "DATE_AS_AT": "2021-07-28",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.02,
@@ -4383,7 +4383,7 @@
     {
         "DATE_AS_AT": "2021-07-29",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.16,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.14,
@@ -4643,7 +4643,7 @@
     {
         "DATE_AS_AT": "2021-07-29",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.4,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.48,
@@ -4903,7 +4903,7 @@
     {
         "DATE_AS_AT": "2021-07-29",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 36.28,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 17.62,
@@ -5163,7 +5163,7 @@
     {
         "DATE_AS_AT": "2021-07-29",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.31,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.66,
@@ -5423,7 +5423,7 @@
     {
         "DATE_AS_AT": "2021-07-29",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.45,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.49,
@@ -5683,7 +5683,7 @@
     {
         "DATE_AS_AT": "2021-07-29",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.09,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.58,
@@ -5943,7 +5943,7 @@
     {
         "DATE_AS_AT": "2021-07-29",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 36.49,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 15.38,
@@ -6203,7 +6203,7 @@
     {
         "DATE_AS_AT": "2021-07-29",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.6,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.54,
@@ -6463,7 +6463,7 @@
     {
         "DATE_AS_AT": "2021-07-30",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.95,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.72,
@@ -6723,7 +6723,7 @@
     {
         "DATE_AS_AT": "2021-07-30",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.78,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.94,
@@ -6983,7 +6983,7 @@
     {
         "DATE_AS_AT": "2021-07-30",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 36.63,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.07,
@@ -7243,7 +7243,7 @@
     {
         "DATE_AS_AT": "2021-07-30",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.16,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.36,
@@ -7503,7 +7503,7 @@
     {
         "DATE_AS_AT": "2021-07-30",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.86,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.95,
@@ -7763,7 +7763,7 @@
     {
         "DATE_AS_AT": "2021-07-30",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.64,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.22,
@@ -8023,7 +8023,7 @@
     {
         "DATE_AS_AT": "2021-07-30",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 36.88,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 15.84,
@@ -8283,7 +8283,7 @@
     {
         "DATE_AS_AT": "2021-07-30",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.96,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.08,
@@ -8543,7 +8543,7 @@
     {
         "DATE_AS_AT": "2021-07-31",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.37,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.07,
@@ -8803,7 +8803,7 @@
     {
         "DATE_AS_AT": "2021-07-31",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.04,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.2,
@@ -9063,7 +9063,7 @@
     {
         "DATE_AS_AT": "2021-07-31",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 36.83,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.32,
@@ -9323,7 +9323,7 @@
     {
         "DATE_AS_AT": "2021-07-31",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.59,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.88,
@@ -9583,7 +9583,7 @@
     {
         "DATE_AS_AT": "2021-07-31",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.09,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.16,
@@ -9843,7 +9843,7 @@
     {
         "DATE_AS_AT": "2021-07-31",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.87,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.43,
@@ -10103,7 +10103,7 @@
     {
         "DATE_AS_AT": "2021-07-31",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 37.17,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 16.12,
@@ -10363,7 +10363,7 @@
     {
         "DATE_AS_AT": "2021-07-31",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.35,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.41,
@@ -10623,7 +10623,7 @@
     {
         "DATE_AS_AT": "2021-08-01",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.57,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.28,
@@ -10883,7 +10883,7 @@
     {
         "DATE_AS_AT": "2021-08-01",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.24,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.37,
@@ -11143,7 +11143,7 @@
     {
         "DATE_AS_AT": "2021-08-01",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 36.97,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.47,
@@ -11403,7 +11403,7 @@
     {
         "DATE_AS_AT": "2021-08-01",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.68,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.06,
@@ -11663,7 +11663,7 @@
     {
         "DATE_AS_AT": "2021-08-01",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.23,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.31,
@@ -11923,7 +11923,7 @@
     {
         "DATE_AS_AT": "2021-08-01",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.04,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.48,
@@ -12183,7 +12183,7 @@
     {
         "DATE_AS_AT": "2021-08-01",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 37.4,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 16.33,
@@ -12443,7 +12443,7 @@
     {
         "DATE_AS_AT": "2021-08-01",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.53,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.66,
@@ -12703,7 +12703,7 @@
     {
         "DATE_AS_AT": "2021-08-02",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.23,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.81,
@@ -12963,7 +12963,7 @@
     {
         "DATE_AS_AT": "2021-08-02",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.58,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.85,
@@ -13223,7 +13223,7 @@
     {
         "DATE_AS_AT": "2021-08-02",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 37.26,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.82,
@@ -13483,7 +13483,7 @@
     {
         "DATE_AS_AT": "2021-08-02",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.88,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.92,
@@ -13743,7 +13743,7 @@
     {
         "DATE_AS_AT": "2021-08-02",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.64,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.75,
@@ -14003,7 +14003,7 @@
     {
         "DATE_AS_AT": "2021-08-02",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.16,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.62,
@@ -14263,7 +14263,7 @@
     {
         "DATE_AS_AT": "2021-08-02",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 37.67,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 16.83,
@@ -14523,7 +14523,7 @@
     {
         "DATE_AS_AT": "2021-08-02",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.81,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.08,
@@ -14783,7 +14783,7 @@
     {
         "DATE_AS_AT": "2021-08-03",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.04,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 20.44,
@@ -15043,7 +15043,7 @@
     {
         "DATE_AS_AT": "2021-08-03",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.92,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 20.29,
@@ -15303,7 +15303,7 @@
     {
         "DATE_AS_AT": "2021-08-03",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 37.68,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.34,
@@ -15563,7 +15563,7 @@
     {
         "DATE_AS_AT": "2021-08-03",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 49.4,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.43,
@@ -15823,7 +15823,7 @@
     {
         "DATE_AS_AT": "2021-08-03",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.07,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 20.23,
@@ -16083,7 +16083,7 @@
     {
         "DATE_AS_AT": "2021-08-03",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.57,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.03,
@@ -16343,7 +16343,7 @@
     {
         "DATE_AS_AT": "2021-08-03",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 38,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 17.39,
@@ -16603,7 +16603,7 @@
     {
         "DATE_AS_AT": "2021-08-03",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 49.2,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.7,
@@ -16863,7 +16863,7 @@
     {
         "DATE_AS_AT": "2021-08-04",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.78,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.04,
@@ -17123,7 +17123,7 @@
     {
         "DATE_AS_AT": "2021-08-04",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.26,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 20.8,
@@ -17383,7 +17383,7 @@
     {
         "DATE_AS_AT": "2021-08-04",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 38.19,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.95,
@@ -17643,7 +17643,7 @@
     {
         "DATE_AS_AT": "2021-08-04",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 49.65,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.77,
@@ -17903,7 +17903,7 @@
     {
         "DATE_AS_AT": "2021-08-04",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.53,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 20.8,
@@ -18163,7 +18163,7 @@
     {
         "DATE_AS_AT": "2021-08-04",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.04,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.7,
@@ -18423,7 +18423,7 @@
     {
         "DATE_AS_AT": "2021-08-04",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 38.39,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 17.9,
@@ -18683,7 +18683,7 @@
     {
         "DATE_AS_AT": "2021-08-04",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 49.58,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.25,
@@ -18943,7 +18943,7 @@
     {
         "DATE_AS_AT": "2021-08-05",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.66,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.68,
@@ -19203,7 +19203,7 @@
     {
         "DATE_AS_AT": "2021-08-05",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.62,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.31,
@@ -19463,7 +19463,7 @@
     {
         "DATE_AS_AT": "2021-08-05",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 38.74,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 20.55,
@@ -19723,7 +19723,7 @@
     {
         "DATE_AS_AT": "2021-08-05",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 49.86,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.07,
@@ -19983,7 +19983,7 @@
     {
         "DATE_AS_AT": "2021-08-05",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.96,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.32,
@@ -20243,7 +20243,7 @@
     {
         "DATE_AS_AT": "2021-08-05",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.63,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.28,
@@ -20503,7 +20503,7 @@
     {
         "DATE_AS_AT": "2021-08-05",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 38.84,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.46,
@@ -20763,7 +20763,7 @@
     {
         "DATE_AS_AT": "2021-08-05",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 50.08,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.76,
@@ -21023,7 +21023,7 @@
     {
         "DATE_AS_AT": "2021-08-06",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.46,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.29,
@@ -21283,7 +21283,7 @@
     {
         "DATE_AS_AT": "2021-08-06",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.87,
@@ -21543,7 +21543,7 @@
     {
         "DATE_AS_AT": "2021-08-06",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.34,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.12,
@@ -21803,7 +21803,7 @@
     {
         "DATE_AS_AT": "2021-08-06",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 50.44,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.64,
@@ -22063,7 +22063,7 @@
     {
         "DATE_AS_AT": "2021-08-06",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.37,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.83,
@@ -22323,7 +22323,7 @@
     {
         "DATE_AS_AT": "2021-08-06",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.16,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.83,
@@ -22583,7 +22583,7 @@
     {
         "DATE_AS_AT": "2021-08-06",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.22,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 18.97,
@@ -22843,7 +22843,7 @@
     {
         "DATE_AS_AT": "2021-08-06",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 50.48,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.2,
@@ -23103,7 +23103,7 @@
     {
         "DATE_AS_AT": "2021-08-07",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.94,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.87,
@@ -23363,7 +23363,7 @@
     {
         "DATE_AS_AT": "2021-08-07",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.25,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.22,
@@ -23623,7 +23623,7 @@
     {
         "DATE_AS_AT": "2021-08-07",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.66,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.41,
@@ -23883,7 +23883,7 @@
     {
         "DATE_AS_AT": "2021-08-07",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 50.85,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.08,
@@ -24143,7 +24143,7 @@
     {
         "DATE_AS_AT": "2021-08-07",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.63,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.13,
@@ -24403,7 +24403,7 @@
     {
         "DATE_AS_AT": "2021-08-07",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.38,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.18,
@@ -24663,7 +24663,7 @@
     {
         "DATE_AS_AT": "2021-08-07",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.49,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.3,
@@ -24923,7 +24923,7 @@
     {
         "DATE_AS_AT": "2021-08-07",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 50.88,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.67,
@@ -25183,7 +25183,7 @@
     {
         "DATE_AS_AT": "2021-08-08",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.2,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.01,
@@ -25443,7 +25443,7 @@
     {
         "DATE_AS_AT": "2021-08-08",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.47,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.47,
@@ -25703,7 +25703,7 @@
     {
         "DATE_AS_AT": "2021-08-08",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.88,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.57,
@@ -25963,7 +25963,7 @@
     {
         "DATE_AS_AT": "2021-08-08",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 50.99,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.38,
@@ -26223,7 +26223,7 @@
     {
         "DATE_AS_AT": "2021-08-08",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.82,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.32,
@@ -26483,7 +26483,7 @@
     {
         "DATE_AS_AT": "2021-08-08",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.48,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.23,
@@ -26743,7 +26743,7 @@
     {
         "DATE_AS_AT": "2021-08-08",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.69,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 19.56,
@@ -27003,7 +27003,7 @@
     {
         "DATE_AS_AT": "2021-08-08",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 51.08,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.97,
@@ -27263,7 +27263,7 @@
     {
         "DATE_AS_AT": "2021-08-09",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.99,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.59,
@@ -27523,7 +27523,7 @@
     {
         "DATE_AS_AT": "2021-08-09",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.89,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.03,
@@ -27783,7 +27783,7 @@
     {
         "DATE_AS_AT": "2021-08-09",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.24,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.95,
@@ -28043,7 +28043,7 @@
     {
         "DATE_AS_AT": "2021-08-09",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 51.88,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.14,
@@ -28303,7 +28303,7 @@
     {
         "DATE_AS_AT": "2021-08-09",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.21,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.79,
@@ -28563,7 +28563,7 @@
     {
         "DATE_AS_AT": "2021-08-09",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.05,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.69,
@@ -28823,7 +28823,7 @@
     {
         "DATE_AS_AT": "2021-08-09",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 39.98,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 20.13,
@@ -29083,7 +29083,7 @@
     {
         "DATE_AS_AT": "2021-08-09",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 51.43,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 28.64,
@@ -29343,7 +29343,7 @@
     {
         "DATE_AS_AT": "2021-08-10",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.06,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.36,
@@ -29603,7 +29603,7 @@
     {
         "DATE_AS_AT": "2021-08-10",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.35,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.59,
@@ -29863,7 +29863,7 @@
     {
         "DATE_AS_AT": "2021-08-10",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.74,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.51,
@@ -30123,7 +30123,7 @@
     {
         "DATE_AS_AT": "2021-08-10",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 52.1,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.47,
@@ -30383,7 +30383,7 @@
     {
         "DATE_AS_AT": "2021-08-10",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.67,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.39,
@@ -30643,7 +30643,7 @@
     {
         "DATE_AS_AT": "2021-08-10",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.56,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 28.21,
@@ -30903,7 +30903,7 @@
     {
         "DATE_AS_AT": "2021-08-10",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.37,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 20.69,
@@ -31163,7 +31163,7 @@
     {
         "DATE_AS_AT": "2021-08-10",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 51.74,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 29.37,
@@ -31423,7 +31423,7 @@
     {
         "DATE_AS_AT": "2021-08-11",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 49.01,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.06,
@@ -31683,7 +31683,7 @@
     {
         "DATE_AS_AT": "2021-08-11",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.85,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.2,
@@ -31943,7 +31943,7 @@
     {
         "DATE_AS_AT": "2021-08-11",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.26,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.07,
@@ -32203,7 +32203,7 @@
     {
         "DATE_AS_AT": "2021-08-11",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 52.55,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 28.2,
@@ -32463,7 +32463,7 @@
     {
         "DATE_AS_AT": "2021-08-11",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.1,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.01,
@@ -32723,7 +32723,7 @@
     {
         "DATE_AS_AT": "2021-08-11",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.17,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 28.83,
@@ -32983,7 +32983,7 @@
     {
         "DATE_AS_AT": "2021-08-11",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 40.79,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.3,
@@ -33243,7 +33243,7 @@
     {
         "DATE_AS_AT": "2021-08-11",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 52.09,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 30.06,
@@ -33503,7 +33503,7 @@
     {
         "DATE_AS_AT": "2021-08-12",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 49.95,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.79,
@@ -33763,7 +33763,7 @@
     {
         "DATE_AS_AT": "2021-08-12",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.37,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.79,
@@ -34023,7 +34023,7 @@
     {
         "DATE_AS_AT": "2021-08-12",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.86,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.66,
@@ -34283,7 +34283,7 @@
     {
         "DATE_AS_AT": "2021-08-12",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 52.81,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 28.61,
@@ -34543,7 +34543,7 @@
     {
         "DATE_AS_AT": "2021-08-12",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.52,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.69,
@@ -34803,7 +34803,7 @@
     {
         "DATE_AS_AT": "2021-08-12",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.82,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 29.46,
@@ -35063,7 +35063,7 @@
     {
         "DATE_AS_AT": "2021-08-12",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.21,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 21.92,
@@ -35323,7 +35323,7 @@
     {
         "DATE_AS_AT": "2021-08-12",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 52.54,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 30.98,
@@ -35583,7 +35583,7 @@
     {
         "DATE_AS_AT": "2021-08-13",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 50.95,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.54,
@@ -35843,7 +35843,7 @@
     {
         "DATE_AS_AT": "2021-08-13",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.94,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.43,
@@ -36103,7 +36103,7 @@
     {
         "DATE_AS_AT": "2021-08-13",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.41,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.23,
@@ -36363,7 +36363,7 @@
     {
         "DATE_AS_AT": "2021-08-13",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 53.86,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 29.94,
@@ -36623,7 +36623,7 @@
     {
         "DATE_AS_AT": "2021-08-13",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.95,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.28,
@@ -36883,7 +36883,7 @@
     {
         "DATE_AS_AT": "2021-08-13",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.4,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 29.99,
@@ -37143,7 +37143,7 @@
     {
         "DATE_AS_AT": "2021-08-13",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.62,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.51,
@@ -37403,7 +37403,7 @@
     {
         "DATE_AS_AT": "2021-08-13",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 52.91,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 31.65,
@@ -37663,7 +37663,7 @@
     {
         "DATE_AS_AT": "2021-08-14",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 51.55,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.92,
@@ -37923,7 +37923,7 @@
     {
         "DATE_AS_AT": "2021-08-14",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.3,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.84,
@@ -38183,7 +38183,7 @@
     {
         "DATE_AS_AT": "2021-08-14",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.77,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.56,
@@ -38443,7 +38443,7 @@
     {
         "DATE_AS_AT": "2021-08-14",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 54.06,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 30.31,
@@ -38703,7 +38703,7 @@
     {
         "DATE_AS_AT": "2021-08-14",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.2,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.59,
@@ -38963,7 +38963,7 @@
     {
         "DATE_AS_AT": "2021-08-14",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.63,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 30.28,
@@ -39223,7 +39223,7 @@
     {
         "DATE_AS_AT": "2021-08-14",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 41.94,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 22.86,
@@ -39483,7 +39483,7 @@
     {
         "DATE_AS_AT": "2021-08-14",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 53.16,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 32.27,
@@ -39743,7 +39743,7 @@
     {
         "DATE_AS_AT": "2021-08-15",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 52.05,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.13,
@@ -40003,7 +40003,7 @@
     {
         "DATE_AS_AT": "2021-08-15",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.39,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.94,
@@ -40263,7 +40263,7 @@
     {
         "DATE_AS_AT": "2021-08-15",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.02,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 24.71,
@@ -40523,7 +40523,7 @@
     {
         "DATE_AS_AT": "2021-08-15",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 54.17,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 30.47,
@@ -40783,7 +40783,7 @@
     {
         "DATE_AS_AT": "2021-08-15",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.37,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.76,
@@ -41043,7 +41043,7 @@
     {
         "DATE_AS_AT": "2021-08-15",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.75,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 30.38,
@@ -41303,7 +41303,7 @@
     {
         "DATE_AS_AT": "2021-08-15",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.16,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.16,
@@ -41563,7 +41563,7 @@
     {
         "DATE_AS_AT": "2021-08-15",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 53.38,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 32.53,
@@ -41823,7 +41823,7 @@
     {
         "DATE_AS_AT": "2021-08-16",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 53.01,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.81,
@@ -42083,7 +42083,7 @@
     {
         "DATE_AS_AT": "2021-08-16",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.11,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.68,
@@ -42343,7 +42343,7 @@
     {
         "DATE_AS_AT": "2021-08-16",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.49,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.18,
@@ -42603,7 +42603,7 @@
     {
         "DATE_AS_AT": "2021-08-16",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 54.78,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 31.27,
@@ -42863,7 +42863,7 @@
     {
         "DATE_AS_AT": "2021-08-16",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 46.78,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.35,
@@ -43123,7 +43123,7 @@
     {
         "DATE_AS_AT": "2021-08-16",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.28,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 30.73,
@@ -43383,7 +43383,7 @@
     {
         "DATE_AS_AT": "2021-08-16",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 42.71,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 23.81,
@@ -43643,7 +43643,7 @@
     {
         "DATE_AS_AT": "2021-08-16",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 53.79,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 33.09,
@@ -43903,7 +43903,7 @@
     {
         "DATE_AS_AT": "2021-08-17",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 54.02,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 28.5,
@@ -44163,7 +44163,7 @@
     {
         "DATE_AS_AT": "2021-08-17",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.67,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.28,
@@ -44423,7 +44423,7 @@
     {
         "DATE_AS_AT": "2021-08-17",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.05,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.71,
@@ -44683,7 +44683,7 @@
     {
         "DATE_AS_AT": "2021-08-17",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 55.9,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 32.18,
@@ -44943,7 +44943,7 @@
     {
         "DATE_AS_AT": "2021-08-17",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.25,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.97,
@@ -45203,7 +45203,7 @@
     {
         "DATE_AS_AT": "2021-08-17",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.94,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 31.17,
@@ -45463,7 +45463,7 @@
     {
         "DATE_AS_AT": "2021-08-17",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.22,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.28,
@@ -45723,7 +45723,7 @@
     {
         "DATE_AS_AT": "2021-08-17",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 54.2,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 33.79,
@@ -45983,7 +45983,7 @@
     {
         "DATE_AS_AT": "2021-08-18",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 55.23,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 29.32,
@@ -46243,7 +46243,7 @@
     {
         "DATE_AS_AT": "2021-08-18",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 49.25,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.96,
@@ -46503,7 +46503,7 @@
     {
         "DATE_AS_AT": "2021-08-18",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.66,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.3,
@@ -46763,7 +46763,7 @@
     {
         "DATE_AS_AT": "2021-08-18",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 56.43,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 32.59,
@@ -47023,7 +47023,7 @@
     {
         "DATE_AS_AT": "2021-08-18",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 47.79,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.64,
@@ -47283,7 +47283,7 @@
     {
         "DATE_AS_AT": "2021-08-18",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 49.7,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 31.89,
@@ -47543,7 +47543,7 @@
     {
         "DATE_AS_AT": "2021-08-18",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 43.92,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.06,
@@ -47803,7 +47803,7 @@
     {
         "DATE_AS_AT": "2021-08-18",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 54.64,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 34.44,
@@ -48063,7 +48063,7 @@
     {
         "DATE_AS_AT": "2021-08-19",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 56.35,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 30.05,
@@ -48323,7 +48323,7 @@
     {
         "DATE_AS_AT": "2021-08-19",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 49.85,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 28.65,
@@ -48583,7 +48583,7 @@
     {
         "DATE_AS_AT": "2021-08-19",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.24,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.84,
@@ -48843,7 +48843,7 @@
     {
         "DATE_AS_AT": "2021-08-19",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 57.54,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 34.13,
@@ -49103,7 +49103,7 @@
     {
         "DATE_AS_AT": "2021-08-19",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.27,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 28.29,
@@ -49363,7 +49363,7 @@
     {
         "DATE_AS_AT": "2021-08-19",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 50.48,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 32.58,
@@ -49623,7 +49623,7 @@
     {
         "DATE_AS_AT": "2021-08-19",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 44.58,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 25.73,
@@ -49883,7 +49883,7 @@
     {
         "DATE_AS_AT": "2021-08-19",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 55.08,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 35.34,
@@ -50143,7 +50143,7 @@
     {
         "DATE_AS_AT": "2021-08-20",
         "STATE": "NSW",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 57.56,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 30.81,
@@ -50403,7 +50403,7 @@
     {
         "DATE_AS_AT": "2021-08-20",
         "STATE": "VIC",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 50.43,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 29.37,
@@ -50663,7 +50663,7 @@
     {
         "DATE_AS_AT": "2021-08-20",
         "STATE": "QLD",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.88,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 27.4,
@@ -50923,7 +50923,7 @@
     {
         "DATE_AS_AT": "2021-08-20",
         "STATE": "ACT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 58.75,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 35.7,
@@ -51183,7 +51183,7 @@
     {
         "DATE_AS_AT": "2021-08-20",
         "STATE": "SA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 48.78,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 28.96,
@@ -51443,7 +51443,7 @@
     {
         "DATE_AS_AT": "2021-08-20",
         "STATE": "NT",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 51.16,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 33.24,
@@ -51703,7 +51703,7 @@
     {
         "DATE_AS_AT": "2021-08-20",
         "STATE": "WA",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 45.13,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 26.36,
@@ -51963,7 +51963,7 @@
     {
         "DATE_AS_AT": "2021-08-20",
         "STATE": "TAS",
-        "AGE_LOWER": 0,
+        "AGE_LOWER": 16,
         "AGE_UPPER": 999,
         "AIR_RESIDENCE_FIRST_DOSE_PCT": 55.51,
         "AIR_RESIDENCE_SECOND_DOSE_PCT": 35.98,

--- a/migrations/correct_pop_grouping.js
+++ b/migrations/correct_pop_grouping.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const _ = require('lodash');
+const { getPopulation } = require('../src/abs_erp');
+
+const PUBLICATION_JSON_PATH = 'docs/data/publications.json';
+const PUBLICATION_JSON_DATA_PATH = 'docs/data/';
+
+let publications = JSON.parse(fs.readFileSync(PUBLICATION_JSON_PATH)).filter(v => v.vaccineDataPath != null);
+
+for(const publication of publications){
+    const localDataFile = publication.vaccineDataPath.replace("https://vaccinedata.covid19nearme.com.au/data/", PUBLICATION_JSON_DATA_PATH);
+    const data = JSON.parse(fs.readFileSync(localDataFile));
+
+    const states = _.get(data, 'pdfData.stateOfResidence');
+    if(states){
+        for(const state in states){
+            const incorrectZeroAgeLower = _.get(states[state], 'ageBucketsActualPopulation', []).find(a => a.ageLower === 0);
+            if(incorrectZeroAgeLower){
+                incorrectZeroAgeLower.ageLower = 16;
+            }
+        }
+        fs.writeFileSync(localDataFile, JSON.stringify(data, null, 4))
+    }
+}

--- a/vaccinepdf.js
+++ b/vaccinepdf.js
@@ -499,7 +499,7 @@ class AusDeptHealthVaccinePdf {
         const secondDoseRow = getRow(rowHeaders[1]).flatMap(z => z.str.split(/\s+/));
         const populationRow = getRow(rowHeaders[2]).flatMap(z => z.str.split(/\s+/));
 
-        const ageGroups = [{ageLower: 0},{ageLower: 50},{ageLower: 70}];
+        const ageGroups = [{ageLower: 16},{ageLower: 50},{ageLower: 70}];
 
         return {
             ageBucketsEstimatedPopulation: ages.map((age, i) => {


### PR DESCRIPTION
Resolves #9

Issue relates to incorrect lower bound specified for AIR residence data.  Data provided is for 16+ age, not 0+ age.

This PR updates the scraper to correctly generate 16+ from now on and also updates existing data to fix this issue.

If required for backwards compatibility, we can regenerate 0+ statistics but I'm not sure if this is required at this stage.